### PR TITLE
Enable building with 1.13 (besides 1.12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ compile: compile-client compile-server compile-csi-proxy-api-gen
 
 .PHONY: compile-client
 compile-client:
-	$(GO_ENV_VARS) go build ./client/...
+	cd client && $(GO_ENV_VARS) go build ./...
 
 .PHONY: compile-server
 compile-server:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 	// https://github.com/kubernetes/gengo/pull/155#issuecomment-537589085
 	// is implemented, and the generic conversion generator merged into code-generator
 	// FIXME: switch back to the upstream repo and/or code-generator!
-	k8s.io/gengo => github.com/wk8/gengo v0.0.0-20191001015530-3d2530bfe606ffd99a90d70ef781861042e23a6f
+	k8s.io/gengo => github.com/wk8/gengo v0.0.0-20191007012548-3d2530bfe606
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/wk8/gengo v0.0.0-20191001015530-3d2530bfe606ffd99a90d70ef781861042e23a6f h1:X1xLpnAmbCIKjEbdexqRY7H8H7qQFtZ9dPUvDRXb/V0=
 github.com/wk8/gengo v0.0.0-20191001015530-3d2530bfe606ffd99a90d70ef781861042e23a6f/go.mod h1:7+jn4yanRF/Ylvd5qyNPUq0VhvOMDhjXrViFtHMcHxI=
+github.com/wk8/gengo v0.0.0-20191007012548-3d2530bfe606 h1:i5JAp+X9ISMaGt0R/9nsiFuNyYN0hXSK9KtphOk/r94=
+github.com/wk8/gengo v0.0.0-20191007012548-3d2530bfe606/go.mod h1:7+jn4yanRF/Ylvd5qyNPUq0VhvOMDhjXrViFtHMcHxI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Upgrading to go 1.13

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
