### PR TITLE
Filesystem test code - lint fix

### DIFF
--- a/integrationtests/filesystem_test.go
+++ b/integrationtests/filesystem_test.go
@@ -140,7 +140,7 @@ func TestFilesystemAPIGroup(t *testing.T) {
 		lnTargetStagePath := fmt.Sprintf("C:\\var\\lib\\kubelet\\plugins\\testplugin-%d.csi.io\\volume%d-tgt-ln", rand1, rand2)
 
 		// 3. Create soft link to the directory and make sure target exists. Success scenario.
-		os.Mkdir(targetStagePath, os.ModeDir)
+		err = os.Mkdir(targetStagePath, os.ModeDir)
 		require.Nil(t, err)
 		defer os.Remove(targetStagePath)
 		// Create a sym link


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Removes the following warning:

``
integrationtests/filesystem_test.go:143:11: Error return value of `os.Mkdir` is not checked (errcheck)
                os.Mkdir(targetStagePath, os.ModeDir)
``

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
