### PR TITLE
fix: SMB remount issue

### DIFF
--- a/internal/os/filesystem/api.go
+++ b/internal/os/filesystem/api.go
@@ -3,6 +3,8 @@ package filesystem
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 )
 
 // Implements the Filesystem OS API calls. All code here should be very simple
@@ -29,6 +31,21 @@ func pathExists(path string) (bool, error) {
 
 func (APIImplementor) PathExists(path string) (bool, error) {
 	return pathExists(path)
+}
+
+func pathValid(path string) (bool, error) {
+	cmd := exec.Command("powershell", "/c", `Test-Path $Env:remoteapth`)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("remoteapth=%s", path))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("returned output: %s, error: %v", string(output), err)
+	}
+
+	return strings.HasPrefix(strings.ToLower(string(output)), "true"), nil
+}
+
+func (APIImplementor) PathValid(path string) (bool, error) {
+	return pathValid(path)
 }
 
 func (APIImplementor) Mkdir(path string) error {

--- a/internal/os/filesystem/api.go
+++ b/internal/os/filesystem/api.go
@@ -44,6 +44,10 @@ func pathValid(path string) (bool, error) {
 	return strings.HasPrefix(strings.ToLower(string(output)), "true"), nil
 }
 
+// PathValid determines whether all elements of a path exist
+//   https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-path?view=powershell-7
+// for a remote path, determines whether connection is ok
+//   e.g. in a SMB server connection, if password is changed, connection will be lost, this func will return false
 func (APIImplementor) PathValid(path string) (bool, error) {
 	return pathValid(path)
 }

--- a/internal/os/filesystem/api_test.go
+++ b/internal/os/filesystem/api_test.go
@@ -1,0 +1,39 @@
+// +build windows
+
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathValid(t *testing.T) {
+	tests := []struct {
+		remotepath     string
+		expectedResult bool
+		expectError    bool
+	}{
+		{
+			"c:",
+			true,
+			false,
+		},
+		{
+			"invalid-path",
+			false,
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := pathValid(test.remotepath)
+		assert.Equal(t, result, test.expectedResult, "Expect result not equal with pathValid(%s) return: %q, expected: %q, error: %v",
+			test.remotepath, result, test.expectedResult, err)
+		if test.expectError {
+			assert.NotNil(t, err, "Expect error during pathValid(%s)", test.remotepath)
+		} else {
+			assert.Nil(t, err, "Expect error is nil during pathValid(%s)", test.remotepath)
+		}
+	}
+}

--- a/internal/server/filesystem/server.go
+++ b/internal/server/filesystem/server.go
@@ -23,6 +23,7 @@ var absPathRegexWindows = regexp.MustCompile(`^[a-zA-Z]:\\`)
 
 type API interface {
 	PathExists(path string) (bool, error)
+	PathValid(path string) (bool, error)
 	Mkdir(path string) error
 	Rmdir(path string, force bool) error
 	LinkPath(tgt string, src string) error
@@ -137,6 +138,12 @@ func (s *Server) PathExists(ctx context.Context, request *internal.PathExistsReq
 		Error:  "",
 		Exists: exists,
 	}, err
+}
+
+// PathValid checks if the given path is accessiable.
+func (s *Server) PathValid(ctx context.Context, path string) (bool, error) {
+	klog.V(4).Infof("calling PathValid with path %q", path)
+	return s.hostAPI.PathValid(path)
 }
 
 func (s *Server) Mkdir(ctx context.Context, request *internal.MkdirRequest, version apiversion.Version) (*internal.MkdirResponse, error) {

--- a/internal/server/filesystem/server_test.go
+++ b/internal/server/filesystem/server_test.go
@@ -13,6 +13,9 @@ type fakeFileSystemAPI struct{}
 func (fakeFileSystemAPI) PathExists(path string) (bool, error) {
 	return true, nil
 }
+func (fakeFileSystemAPI) PathValid(path string) (bool, error) {
+	return true, nil
+}
 func (fakeFileSystemAPI) Mkdir(path string) error {
 	return nil
 }

--- a/internal/server/smb/server_test.go
+++ b/internal/server/smb/server_test.go
@@ -32,6 +32,9 @@ type fakeFileSystemAPI struct{}
 func (fakeFileSystemAPI) PathExists(path string) (bool, error) {
 	return true, nil
 }
+func (fakeFileSystemAPI) PathValid(path string) (bool, error) {
+	return true, nil
+}
 func (fakeFileSystemAPI) Mkdir(path string) error {
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Porting PR(https://github.com/kubernetes/utils/pull/184) to csi-proxy.
There is a critical bug in original SMB mount logic:

   When SMB server password changed, there is no way for csi-proxy to remove original SMB server connection, only workaround is user log on to the Windows agent node, and run `Remove-SMBGlobalMapping` command manually to remove that connection. This PR could fix the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/assign @jingxu97 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: SMB remount issue
```
