### PR TITLE
Fix error string to not be VM specific

### DIFF
--- a/internal/os/system/api.go
+++ b/internal/os/system/api.go
@@ -33,7 +33,7 @@ func (APIImplementor) GetBIOSSerialNumber() (string, error) {
 		}
 	})
 	if len(lines) != 2 {
-		return "", fmt.Errorf("received unexpected value retrieving vm uuid: %q", string(result))
+		return "", fmt.Errorf("received unexpected value retrieving host uuid: %q", string(result))
 	}
 	return lines[1], nil
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixup an error string to not assume host is a VM.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
