### PR TITLE
fix: add trailing backslash to remote path when linking to SMB shares

### DIFF
--- a/internal/os/smb/api.go
+++ b/internal/os/smb/api.go
@@ -38,6 +38,13 @@ func (APIImplementor) IsSmbMapped(remotePath string) (bool, error) {
 // alpha to merge the paths.
 // TODO (for beta release): Merge the link paths - os.Symlink and Powershell link path.
 func (APIImplementor) NewSmbLink(remotePath, localPath string) error {
+
+	if !strings.HasSuffix(remotePath, "\\") {
+		// Golang has issues resolving paths mapped to file shares if they do not end in a trailing \
+		// so add one if needed.
+		remotePath = remotePath + "\\"
+	}
+
 	cmdLine := fmt.Sprintf(`New-Item -ItemType SymbolicLink $Env:smblocalPath -Target $Env:smbremotepath`)
 	cmd := exec.Command("powershell", "/c", cmdLine)
 	cmd.Env = append(os.Environ(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR addresses an issue where golang fails to properly evaluate symlinks on windows if the link source is remote file share AND there is no trailing backslash (ex: \\server\share will not work but \\server\share\ will work).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/94213

**Special notes for your reviewer**:
This issue is only seen on containerd (not Docker).
Kevin Parsons (@kevpar) investigated this and believes it is becasue docker does not call EvalSymLinks but containerd does.

We'll follow up with a golang bug for this too.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Working around some issues with how golang evaluates symlink targets by appending a trailing \ when creating symlinks to SMB shares.
```
