### PR TITLE
fix smb mount PermissionDenied issue on Windows

### DIFF
--- a/internal/os/smb/api.go
+++ b/internal/os/smb/api.go
@@ -64,7 +64,7 @@ func (APIImplementor) NewSmbGlobalMapping(remotePath, username, password string)
 	// https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-5.1
 	cmdLine := fmt.Sprintf(`$PWord = ConvertTo-SecureString -String $Env:smbpassword -AsPlainText -Force` +
 		`;$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $Env:smbuser, $PWord` +
-		`;New-SmbGlobalMapping -RemotePath $Env:smbremotepath -Credential $Credential`)
+		`;New-SmbGlobalMapping -RemotePath $Env:smbremotepath -Credential $Credential -RequirePrivacy $true`)
 
 	cmd := exec.Command("powershell", "/c", cmdLine)
 	cmd.Env = append(os.Environ(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
fix smb mount PermissionDenied issue on Windows

code ported from https://github.com/kubernetes/kubernetes/pull/99550

issue details could be found here: https://github.com/moby/moby/issues/37863
```
Just use the -RequirePrivacy $true along with the New-SMBGlobalMapping.

MUP cache seems to be a problem here. The MUP cache clears every 15 minutes and the credentials to the SMB File Share are not saved.

New commands looks like - New-SMBGlobalMapping -RemotePath \contosofileserver\share1 -LocalPath G: -RequirePrivacy $true
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix smb mount PermissionDenied issue on Windows
```
