### PR TITLE
Add another client per API that can communicate with a custom named pipe

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Microsoft/go-winio v0.4.16
 	github.com/golang/protobuf v1.4.1
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.2.2
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.25.0

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,9 +1,9 @@
 module github.com/kubernetes-csi/csi-proxy/client
 
-go 1.12
+go 1.16
 
 require (
-	github.com/Microsoft/go-winio v0.4.14
+	github.com/Microsoft/go-winio v0.4.16
 	github.com/golang/protobuf v1.4.1
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.2.2

--- a/client/go.sum
+++ b/client/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
+github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
+github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -30,6 +32,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -56,6 +60,8 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qdNLDHHtQ4mlgQIZPPNA=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3 h1:7TYNF4UdlohbFwpNH04CoPMp1cHUZgO1Ebq5r2hIjfo=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/client/groups/disk/v1/client_generated.go
+++ b/client/groups/disk/v1/client_generated.go
@@ -4,7 +4,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"

--- a/client/groups/disk/v1/client_generated.go
+++ b/client/groups/disk/v1/client_generated.go
@@ -4,18 +4,21 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/disk/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/disk/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"google.golang.org/grpc"
 )
 
-const groupName = "disk"
+// GroupName is the group name of this API.
+const GroupName = "disk"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.DiskClient
@@ -25,7 +28,19 @@ type Client struct {
 // NewClient returns a client to make calls to the disk API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/disk/v1alpha1/client_generated.go
+++ b/client/groups/disk/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "disk"
+// GroupName is the group name of this API.
+const GroupName = "disk"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.DiskClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the disk API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/disk/v1beta1/client_generated.go
+++ b/client/groups/disk/v1beta1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "disk"
+// GroupName is the group name of this API.
+const GroupName = "disk"
 
-var version = apiversion.NewVersionOrPanic("v1beta1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1beta1")
 
 type Client struct {
 	client     v1beta1.DiskClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the disk API group version v1beta1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/disk/v1beta2/client_generated.go
+++ b/client/groups/disk/v1beta2/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "disk"
+// GroupName is the group name of this API.
+const GroupName = "disk"
 
-var version = apiversion.NewVersionOrPanic("v1beta2")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1beta2")
 
 type Client struct {
 	client     v1beta2.DiskClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the disk API group version v1beta2.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/filesystem/v1/client_generated.go
+++ b/client/groups/filesystem/v1/client_generated.go
@@ -4,7 +4,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"

--- a/client/groups/filesystem/v1/client_generated.go
+++ b/client/groups/filesystem/v1/client_generated.go
@@ -4,18 +4,21 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/filesystem/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/filesystem/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"google.golang.org/grpc"
 )
 
-const groupName = "filesystem"
+// GroupName is the group name of this API.
+const GroupName = "filesystem"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.FilesystemClient
@@ -25,7 +28,19 @@ type Client struct {
 // NewClient returns a client to make calls to the filesystem API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/filesystem/v1alpha1/client_generated.go
+++ b/client/groups/filesystem/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "filesystem"
+// GroupName is the group name of this API.
+const GroupName = "filesystem"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.FilesystemClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the filesystem API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/filesystem/v1beta1/client_generated.go
+++ b/client/groups/filesystem/v1beta1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "filesystem"
+// GroupName is the group name of this API.
+const GroupName = "filesystem"
 
-var version = apiversion.NewVersionOrPanic("v1beta1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1beta1")
 
 type Client struct {
 	client     v1beta1.FilesystemClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the filesystem API group version v1beta1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/iscsi/v1alpha1/client_generated.go
+++ b/client/groups/iscsi/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "iscsi"
+// GroupName is the group name of this API.
+const GroupName = "iscsi"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.IscsiClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the iscsi API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/iscsi/v1alpha2/client_generated.go
+++ b/client/groups/iscsi/v1alpha2/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "iscsi"
+// GroupName is the group name of this API.
+const GroupName = "iscsi"
 
-var version = apiversion.NewVersionOrPanic("v1alpha2")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha2")
 
 type Client struct {
 	client     v1alpha2.IscsiClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the iscsi API group version v1alpha2.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/smb/v1/client_generated.go
+++ b/client/groups/smb/v1/client_generated.go
@@ -4,7 +4,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"

--- a/client/groups/smb/v1/client_generated.go
+++ b/client/groups/smb/v1/client_generated.go
@@ -4,18 +4,21 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/smb/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/smb/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"google.golang.org/grpc"
 )
 
-const groupName = "smb"
+// GroupName is the group name of this API.
+const GroupName = "smb"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.SmbClient
@@ -25,7 +28,19 @@ type Client struct {
 // NewClient returns a client to make calls to the smb API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/smb/v1alpha1/client_generated.go
+++ b/client/groups/smb/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "smb"
+// GroupName is the group name of this API.
+const GroupName = "smb"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.SmbClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the smb API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/smb/v1beta1/client_generated.go
+++ b/client/groups/smb/v1beta1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "smb"
+// GroupName is the group name of this API.
+const GroupName = "smb"
 
-var version = apiversion.NewVersionOrPanic("v1beta1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1beta1")
 
 type Client struct {
 	client     v1beta1.SmbClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the smb API group version v1beta1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/system/v1alpha1/client_generated.go
+++ b/client/groups/system/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "system"
+// GroupName is the group name of this API.
+const GroupName = "system"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.SystemClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the system API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/volume/v1/client_generated.go
+++ b/client/groups/volume/v1/client_generated.go
@@ -4,7 +4,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"

--- a/client/groups/volume/v1/client_generated.go
+++ b/client/groups/volume/v1/client_generated.go
@@ -4,18 +4,21 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/volume/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/volume/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"google.golang.org/grpc"
 )
 
-const groupName = "volume"
+// GroupName is the group name of this API.
+const GroupName = "volume"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.VolumeClient
@@ -25,7 +28,19 @@ type Client struct {
 // NewClient returns a client to make calls to the volume API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/volume/v1alpha1/client_generated.go
+++ b/client/groups/volume/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "volume"
+// GroupName is the group name of this API.
+const GroupName = "volume"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.VolumeClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the volume API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/volume/v1beta1/client_generated.go
+++ b/client/groups/volume/v1beta1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "volume"
+// GroupName is the group name of this API.
+const GroupName = "volume"
 
-var version = apiversion.NewVersionOrPanic("v1beta1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1beta1")
 
 type Client struct {
 	client     v1beta1.VolumeClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the volume API group version v1beta1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/groups/volume/v1beta2/client_generated.go
+++ b/client/groups/volume/v1beta2/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "volume"
+// GroupName is the group name of this API.
+const GroupName = "volume"
 
-var version = apiversion.NewVersionOrPanic("v1beta2")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1beta2")
 
 type Client struct {
 	client     v1beta2.VolumeClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the volume API group version v1beta2.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	"errors"
+	"os"
+
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 )
 
@@ -16,4 +19,17 @@ const (
 
 func PipePath(apiGroupName string, apiVersion apiversion.Version) string {
 	return pipePrefix + csiProxyNamedPipePrefix + apiGroupName + "-" + apiVersion.String()
+}
+
+// FindFirstNamedPipe finds the first named pipe available at the Windows named pipe locations.
+// Only the first version from `apiVersions` that exists will be returned, this mechanism
+// allows picking the first version available in the case where there's a beta and v1 API
+func FindFirstNamedPipe(apiGroupName string, apiVersions []apiversion.Version) (string, error) {
+	for _, version := range apiVersions {
+		namedPipe := PipePath(apiGroupName, version)
+		if _, err := os.Lstat(namedPipe); err != nil {
+			return namedPipe, nil
+		}
+	}
+	return "", errors.New("Couldn't find a valid named pipe")
 }

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,9 +1,6 @@
 package client
 
 import (
-	"errors"
-	"os"
-
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 )
 
@@ -19,17 +16,4 @@ const (
 
 func PipePath(apiGroupName string, apiVersion apiversion.Version) string {
 	return pipePrefix + csiProxyNamedPipePrefix + apiGroupName + "-" + apiVersion.String()
-}
-
-// FindFirstNamedPipe finds the first named pipe available at the Windows named pipe locations.
-// Only the first version from `apiVersions` that exists will be returned, this mechanism
-// allows picking the first version available in the case where there's a beta and v1 API
-func FindFirstNamedPipe(apiGroupName string, apiVersions []apiversion.Version) (string, error) {
-	for _, version := range apiVersions {
-		namedPipe := PipePath(apiGroupName, version)
-		if _, err := os.Lstat(namedPipe); err != nil {
-			return namedPipe, nil
-		}
-	}
-	return "", errors.New("Couldn't find a valid named pipe")
 }

--- a/cmd/csi-proxy-api-gen/generators/client_generated_gen.go
+++ b/cmd/csi-proxy-api-gen/generators/client_generated_gen.go
@@ -32,7 +32,6 @@ func (g *clientGeneratedGenerator) Imports(*generator.Context) []string {
 	return []string{
 		"context",
 		"net",
-		"fmt",
 		"github.com/Microsoft/go-winio",
 		"google.golang.org/grpc",
 		"github.com/kubernetes-csi/csi-proxy/client",

--- a/cmd/csi-proxy-api-gen/generators/client_generated_gen.go
+++ b/cmd/csi-proxy-api-gen/generators/client_generated_gen.go
@@ -32,6 +32,7 @@ func (g *clientGeneratedGenerator) Imports(*generator.Context) []string {
 	return []string{
 		"context",
 		"net",
+		"fmt",
 		"github.com/Microsoft/go-winio",
 		"google.golang.org/grpc",
 		"github.com/kubernetes-csi/csi-proxy/client",
@@ -44,9 +45,11 @@ func (g *clientGeneratedGenerator) Init(context *generator.Context, writer io.Wr
 	snippetWriter := generator.NewSnippetWriter(writer, context, "$", "$")
 
 	snippetWriter.Do(`
-const groupName = "$.groupName$"
+// GroupName is the group name of this API.
+const GroupName = "$.groupName$"
 
-var version = apiversion.NewVersionOrPanic("$.version$")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("$.version$")
 
 type Client struct {
 	client     $.version$.$.camelGroupName$Client
@@ -56,7 +59,19 @@ type Client struct {
 // NewClient returns a client to make calls to the $.groupName$ API group version $.version$.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,12 @@ replace (
 )
 
 require (
-	github.com/Microsoft/go-winio v0.4.14
+	github.com/Microsoft/go-winio v0.4.16
 	github.com/golang/protobuf v1.4.1
 	github.com/google/go-cmp v0.5.0
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/kubernetes-csi/csi-proxy/client v0.0.0-00010101000000-000000000000
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -33,7 +33,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365 h1:ECW73yc9MY7935nNYXUkK7Dz17YuSUI9yqRqYS8aBww=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
+github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
+github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,6 +37,8 @@ github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73t
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -69,6 +73,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
-github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -35,7 +33,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365 h1:ECW73yc9MY7935nNYXUkK7Dz17YuSUI9yqRqYS8aBww=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -72,7 +69,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/integrationtests/apigroups/client/dummy/v1/client_generated.go
+++ b/integrationtests/apigroups/client/dummy/v1/client_generated.go
@@ -4,7 +4,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"

--- a/integrationtests/apigroups/client/dummy/v1/client_generated.go
+++ b/integrationtests/apigroups/client/dummy/v1/client_generated.go
@@ -4,18 +4,21 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
-	v1 "github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/api/dummy/v1"
+	"github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/api/dummy/v1"
 	"google.golang.org/grpc"
 )
 
-const groupName = "dummy"
+// GroupName is the group name of this API.
+const GroupName = "dummy"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.DummyClient
@@ -25,7 +28,19 @@ type Client struct {
 // NewClient returns a client to make calls to the dummy API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/integrationtests/apigroups/client/dummy/v1alpha1/client_generated.go
+++ b/integrationtests/apigroups/client/dummy/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "dummy"
+// GroupName is the group name of this API.
+const GroupName = "dummy"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.DummyClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the dummy API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/integrationtests/apigroups/client/dummy/v1alpha2/client_generated.go
+++ b/integrationtests/apigroups/client/dummy/v1alpha2/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "dummy"
+// GroupName is the group name of this API.
+const GroupName = "dummy"
 
-var version = apiversion.NewVersionOrPanic("v1alpha2")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha2")
 
 type Client struct {
 	client     v1alpha2.DummyClient
@@ -25,7 +27,19 @@ type Client struct {
 // NewClient returns a client to make calls to the dummy API group version v1alpha2.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {

--- a/integrationtests/apigroups/server/dummy/api_group_generated.go
+++ b/integrationtests/apigroups/server/dummy/api_group_generated.go
@@ -5,7 +5,7 @@ package dummy
 import (
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/server/dummy/internal"
-	v1 "github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/server/dummy/internal/v1"
+	"github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/server/dummy/internal/v1"
 	"github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/server/dummy/internal/v1alpha1"
 	"github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/server/dummy/internal/v1alpha2"
 	srvtypes "github.com/kubernetes-csi/csi-proxy/internal/server/types"

--- a/integrationtests/apigroups/server/dummy/internal/v1/server_generated.go
+++ b/integrationtests/apigroups/server/dummy/internal/v1/server_generated.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
-	v1 "github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/api/dummy/v1"
+	"github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/api/dummy/v1"
 	"github.com/kubernetes-csi/csi-proxy/integrationtests/apigroups/server/dummy/internal"
 	"google.golang.org/grpc"
 )

--- a/internal/server/disk/api_group_generated.go
+++ b/internal/server/disk/api_group_generated.go
@@ -5,7 +5,7 @@ package disk
 import (
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/disk/internal"
-	v1 "github.com/kubernetes-csi/csi-proxy/internal/server/disk/internal/v1"
+	"github.com/kubernetes-csi/csi-proxy/internal/server/disk/internal/v1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/disk/internal/v1alpha1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/disk/internal/v1beta1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/disk/internal/v1beta2"

--- a/internal/server/disk/internal/v1/server_generated.go
+++ b/internal/server/disk/internal/v1/server_generated.go
@@ -5,7 +5,7 @@ package v1
 import (
 	"context"
 
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/disk/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/disk/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/disk/internal"
 	"google.golang.org/grpc"

--- a/internal/server/filesystem/api_group_generated.go
+++ b/internal/server/filesystem/api_group_generated.go
@@ -5,7 +5,7 @@ package filesystem
 import (
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/filesystem/internal"
-	v1 "github.com/kubernetes-csi/csi-proxy/internal/server/filesystem/internal/v1"
+	"github.com/kubernetes-csi/csi-proxy/internal/server/filesystem/internal/v1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/filesystem/internal/v1alpha1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/filesystem/internal/v1beta1"
 	srvtypes "github.com/kubernetes-csi/csi-proxy/internal/server/types"

--- a/internal/server/filesystem/internal/v1/server_generated.go
+++ b/internal/server/filesystem/internal/v1/server_generated.go
@@ -5,7 +5,7 @@ package v1
 import (
 	"context"
 
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/filesystem/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/filesystem/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/filesystem/internal"
 	"google.golang.org/grpc"

--- a/internal/server/smb/api_group_generated.go
+++ b/internal/server/smb/api_group_generated.go
@@ -5,7 +5,7 @@ package smb
 import (
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/smb/internal"
-	v1 "github.com/kubernetes-csi/csi-proxy/internal/server/smb/internal/v1"
+	"github.com/kubernetes-csi/csi-proxy/internal/server/smb/internal/v1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/smb/internal/v1alpha1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/smb/internal/v1beta1"
 	srvtypes "github.com/kubernetes-csi/csi-proxy/internal/server/types"

--- a/internal/server/smb/internal/v1/server_generated.go
+++ b/internal/server/smb/internal/v1/server_generated.go
@@ -5,7 +5,7 @@ package v1
 import (
 	"context"
 
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/smb/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/smb/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/smb/internal"
 	"google.golang.org/grpc"

--- a/internal/server/volume/api_group_generated.go
+++ b/internal/server/volume/api_group_generated.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	srvtypes "github.com/kubernetes-csi/csi-proxy/internal/server/types"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/volume/internal"
-	v1 "github.com/kubernetes-csi/csi-proxy/internal/server/volume/internal/v1"
+	"github.com/kubernetes-csi/csi-proxy/internal/server/volume/internal/v1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/volume/internal/v1alpha1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/volume/internal/v1beta1"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/volume/internal/v1beta2"

--- a/internal/server/volume/internal/v1/server_generated.go
+++ b/internal/server/volume/internal/v1/server_generated.go
@@ -5,7 +5,7 @@ package v1
 import (
 	"context"
 
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/volume/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/volume/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/volume/internal"
 	"google.golang.org/grpc"

--- a/vendor/github.com/Microsoft/go-winio/go.mod
+++ b/vendor/github.com/Microsoft/go-winio/go.mod
@@ -3,7 +3,7 @@ module github.com/Microsoft/go-winio
 go 1.12
 
 require (
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.1
-	golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b
+	golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3
 )

--- a/vendor/github.com/Microsoft/go-winio/go.sum
+++ b/vendor/github.com/Microsoft/go-winio/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
@@ -12,5 +12,5 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qdNLDHHtQ4mlgQIZPPNA=
-golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3 h1:7TYNF4UdlohbFwpNH04CoPMp1cHUZgO1Ebq5r2hIjfo=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/Microsoft/go-winio/pipe.go
+++ b/vendor/github.com/Microsoft/go-winio/pipe.go
@@ -182,13 +182,14 @@ func (s pipeAddress) String() string {
 }
 
 // tryDialPipe attempts to dial the pipe at `path` until `ctx` cancellation or timeout.
-func tryDialPipe(ctx context.Context, path *string) (syscall.Handle, error) {
+func tryDialPipe(ctx context.Context, path *string, access uint32) (syscall.Handle, error) {
 	for {
+
 		select {
 		case <-ctx.Done():
 			return syscall.Handle(0), ctx.Err()
 		default:
-			h, err := createFile(*path, syscall.GENERIC_READ|syscall.GENERIC_WRITE, 0, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_OVERLAPPED|cSECURITY_SQOS_PRESENT|cSECURITY_ANONYMOUS, 0)
+			h, err := createFile(*path, access, 0, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_OVERLAPPED|cSECURITY_SQOS_PRESENT|cSECURITY_ANONYMOUS, 0)
 			if err == nil {
 				return h, nil
 			}
@@ -197,7 +198,7 @@ func tryDialPipe(ctx context.Context, path *string) (syscall.Handle, error) {
 			}
 			// Wait 10 msec and try again. This is a rather simplistic
 			// view, as we always try each 10 milliseconds.
-			time.Sleep(time.Millisecond * 10)
+			time.Sleep(10 * time.Millisecond)
 		}
 	}
 }
@@ -210,7 +211,7 @@ func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
 	if timeout != nil {
 		absTimeout = time.Now().Add(*timeout)
 	} else {
-		absTimeout = time.Now().Add(time.Second * 2)
+		absTimeout = time.Now().Add(2 * time.Second)
 	}
 	ctx, _ := context.WithDeadline(context.Background(), absTimeout)
 	conn, err := DialPipeContext(ctx, path)
@@ -223,9 +224,15 @@ func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
 // DialPipeContext attempts to connect to a named pipe by `path` until `ctx`
 // cancellation or timeout.
 func DialPipeContext(ctx context.Context, path string) (net.Conn, error) {
+	return DialPipeAccess(ctx, path, syscall.GENERIC_READ|syscall.GENERIC_WRITE)
+}
+
+// DialPipeAccess attempts to connect to a named pipe by `path` with `access` until `ctx`
+// cancellation or timeout.
+func DialPipeAccess(ctx context.Context, path string, access uint32) (net.Conn, error) {
 	var err error
 	var h syscall.Handle
-	h, err = tryDialPipe(ctx, &path)
+	h, err = tryDialPipe(ctx, &path, access)
 	if err != nil {
 		return nil, err
 	}
@@ -422,10 +429,10 @@ type PipeConfig struct {
 	// when the pipe is in message mode.
 	MessageMode bool
 
-	// InputBufferSize specifies the size the input buffer, in bytes.
+	// InputBufferSize specifies the size of the input buffer, in bytes.
 	InputBufferSize int32
 
-	// OutputBufferSize specifies the size the input buffer, in bytes.
+	// OutputBufferSize specifies the size of the output buffer, in bytes.
 	OutputBufferSize int32
 }
 

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/go.mod
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Microsoft/go-winio v0.4.16
 	github.com/golang/protobuf v1.4.1
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.2.2
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.25.0

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/go.mod
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/go.mod
@@ -1,9 +1,9 @@
 module github.com/kubernetes-csi/csi-proxy/client
 
-go 1.12
+go 1.16
 
 require (
-	github.com/Microsoft/go-winio v0.4.14
+	github.com/Microsoft/go-winio v0.4.16
 	github.com/golang/protobuf v1.4.1
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.2.2

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/go.sum
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
+github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
+github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -30,6 +32,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -56,6 +60,8 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qdNLDHHtQ4mlgQIZPPNA=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3 h1:7TYNF4UdlohbFwpNH04CoPMp1cHUZgO1Ebq5r2hIjfo=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/disk/v1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/disk/v1/client_generated.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/disk/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/disk/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"google.golang.org/grpc"
 )
@@ -31,7 +31,8 @@ func NewClient() (*Client, error) {
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure())
+		grpc.WithInsecure(),
+		grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/disk/v1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/disk/v1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "disk"
+// GroupName is the group name of this API.
+const GroupName = "disk"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.DiskClient
@@ -25,14 +27,25 @@ type Client struct {
 // NewClient returns a client to make calls to the disk API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure(),
-		grpc.WithBlock())
+		grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/filesystem/v1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/filesystem/v1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "filesystem"
+// GroupName is the group name of this API.
+const GroupName = "filesystem"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.FilesystemClient
@@ -25,14 +27,25 @@ type Client struct {
 // NewClient returns a client to make calls to the filesystem API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure(),
-		grpc.WithBlock())
+		grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/filesystem/v1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/filesystem/v1/client_generated.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/filesystem/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/filesystem/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"google.golang.org/grpc"
 )
@@ -31,7 +31,8 @@ func NewClient() (*Client, error) {
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure())
+		grpc.WithInsecure(),
+		grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/iscsi/v1alpha2/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/iscsi/v1alpha2/client_generated.go
@@ -31,7 +31,8 @@ func NewClient() (*Client, error) {
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure())
+		grpc.WithInsecure(),
+		grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/iscsi/v1alpha2/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/iscsi/v1alpha2/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "iscsi"
+// GroupName is the group name of this API.
+const GroupName = "iscsi"
 
-var version = apiversion.NewVersionOrPanic("v1alpha2")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha2")
 
 type Client struct {
 	client     v1alpha2.IscsiClient
@@ -25,14 +27,25 @@ type Client struct {
 // NewClient returns a client to make calls to the iscsi API group version v1alpha2.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure(),
-		grpc.WithBlock())
+		grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/smb/v1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/smb/v1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "smb"
+// GroupName is the group name of this API.
+const GroupName = "smb"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.SmbClient
@@ -25,14 +27,25 @@ type Client struct {
 // NewClient returns a client to make calls to the smb API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure(),
-		grpc.WithBlock())
+		grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/smb/v1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/smb/v1/client_generated.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/smb/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/smb/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"google.golang.org/grpc"
 )
@@ -31,7 +31,8 @@ func NewClient() (*Client, error) {
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure())
+		grpc.WithInsecure(),
+		grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/system/v1alpha1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/system/v1alpha1/client_generated.go
@@ -31,7 +31,8 @@ func NewClient() (*Client, error) {
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure())
+		grpc.WithInsecure(),
+		grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/system/v1alpha1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/system/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "system"
+// GroupName is the group name of this API.
+const GroupName = "system"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.SystemClient
@@ -25,14 +27,25 @@ type Client struct {
 // NewClient returns a client to make calls to the system API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure(),
-		grpc.WithBlock())
+		grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "volume"
+// GroupName is the group name of this API.
+const GroupName = "volume"
 
-var version = apiversion.NewVersionOrPanic("v1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1")
 
 type Client struct {
 	client     v1.VolumeClient
@@ -25,14 +27,25 @@ type Client struct {
 // NewClient returns a client to make calls to the volume API group version v1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure(),
-		grpc.WithBlock())
+		grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1/client_generated.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/kubernetes-csi/csi-proxy/client"
-	v1 "github.com/kubernetes-csi/csi-proxy/client/api/volume/v1"
+	"github.com/kubernetes-csi/csi-proxy/client/api/volume/v1"
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	"google.golang.org/grpc"
 )
@@ -31,7 +31,8 @@ func NewClient() (*Client, error) {
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure())
+		grpc.WithInsecure(),
+		grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1alpha1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1alpha1/client_generated.go
@@ -31,7 +31,8 @@ func NewClient() (*Client, error) {
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure())
+		grpc.WithInsecure(),
+		grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1alpha1/client_generated.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1alpha1/client_generated.go
@@ -13,9 +13,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-const groupName = "volume"
+// GroupName is the group name of this API.
+const GroupName = "volume"
 
-var version = apiversion.NewVersionOrPanic("v1alpha1")
+// Version is the api version.
+var Version = apiversion.NewVersionOrPanic("v1alpha1")
 
 type Client struct {
 	client     v1alpha1.VolumeClient
@@ -25,14 +27,25 @@ type Client struct {
 // NewClient returns a client to make calls to the volume API group version v1alpha1.
 // It's the caller's responsibility to Close the client when done.
 func NewClient() (*Client, error) {
-	pipePath := client.PipePath(groupName, version)
+	pipePath := client.PipePath(GroupName, Version)
+	return NewClientWithPipePath(pipePath)
+}
+
+// NewClientWithPipePath returns a client to make calls to the named pipe located at "pipePath".
+// It's the caller's responsibility to Close the client when done.
+func NewClientWithPipePath(pipePath string) (*Client, error) {
+
+	// verify that the pipe exists
+	_, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	connection, err := grpc.Dial(pipePath,
 		grpc.WithContextDialer(func(context context.Context, s string) (net.Conn, error) {
 			return winio.DialPipeContext(context, s)
 		}),
-		grpc.WithInsecure(),
-		grpc.WithBlock())
+		grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,15 +1,10 @@
 language: go
 go_import_path: github.com/pkg/errors
 go:
-  - 1.4.x
-  - 1.5.x
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
   - 1.11.x
+  - 1.12.x
+  - 1.13.x
   - tip
 
 script:
-  - go test -v ./...
+  - make check

--- a/vendor/github.com/pkg/errors/Makefile
+++ b/vendor/github.com/pkg/errors/Makefile
@@ -1,0 +1,44 @@
+PKGS := github.com/pkg/errors
+SRCDIRS := $(shell go list -f '{{.Dir}}' $(PKGS))
+GO := go
+
+check: test vet gofmt misspell unconvert staticcheck ineffassign unparam
+
+test: 
+	$(GO) test $(PKGS)
+
+vet: | test
+	$(GO) vet $(PKGS)
+
+staticcheck:
+	$(GO) get honnef.co/go/tools/cmd/staticcheck
+	staticcheck -checks all $(PKGS)
+
+misspell:
+	$(GO) get github.com/client9/misspell/cmd/misspell
+	misspell \
+		-locale GB \
+		-error \
+		*.md *.go
+
+unconvert:
+	$(GO) get github.com/mdempsky/unconvert
+	unconvert -v $(PKGS)
+
+ineffassign:
+	$(GO) get github.com/gordonklaus/ineffassign
+	find $(SRCDIRS) -name '*.go' | xargs ineffassign
+
+pedantic: check errcheck
+
+unparam:
+	$(GO) get mvdan.cc/unparam
+	unparam ./...
+
+errcheck:
+	$(GO) get github.com/kisielk/errcheck
+	errcheck $(PKGS)
+
+gofmt:  
+	@echo Checking code is gofmted
+	@test -z "$(shell gofmt -s -l -d -e $(SRCDIRS) | tee /dev/stderr)"

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -41,11 +41,18 @@ default:
 
 [Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
 
+## Roadmap
+
+With the upcoming [Go2 error proposals](https://go.googlesource.com/proposal/+/master/design/go2draft.md) this package is moving into maintenance mode. The roadmap for a 1.0 release is as follows:
+
+- 0.9. Remove pre Go 1.9 and Go 1.10 support, address outstanding pull requests (if possible)
+- 1.0. Final release.
+
 ## Contributing
 
-We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+Because of the Go2 errors changes, this package is not accepting proposals for new functionality. With that said, we welcome pull requests, bug fixes and issue reports. 
 
-Before proposing a change, please discuss your change by raising an issue.
+Before sending a PR, please discuss your change by raising an issue.
 
 ## License
 

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -82,7 +82,7 @@
 //
 //     if err, ok := err.(stackTracer); ok {
 //             for _, f := range err.StackTrace() {
-//                     fmt.Printf("%+s:%d", f)
+//                     fmt.Printf("%+s:%d\n", f, f)
 //             }
 //     }
 //
@@ -158,6 +158,9 @@ type withStack struct {
 }
 
 func (w *withStack) Cause() error { return w.error }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withStack) Unwrap() error { return w.error }
 
 func (w *withStack) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -240,6 +243,9 @@ type withMessage struct {
 
 func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
 func (w *withMessage) Cause() error  { return w.cause }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withMessage) Unwrap() error { return w.cause }
 
 func (w *withMessage) Format(s fmt.State, verb rune) {
 	switch verb {

--- a/vendor/github.com/pkg/errors/go113.go
+++ b/vendor/github.com/pkg/errors/go113.go
@@ -1,0 +1,38 @@
+// +build go1.13
+
+package errors
+
+import (
+	stderrors "errors"
+)
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool { return stderrors.Is(err, target) }
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// As will panic if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type. As returns false if err is nil.
+func As(err error, target interface{}) bool { return stderrors.As(err, target) }
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	return stderrors.Unwrap(err)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Microsoft/go-winio v0.4.14
+# github.com/Microsoft/go-winio v0.4.16
 ## explicit
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/guid
@@ -52,7 +52,7 @@ github.com/kubernetes-csi/csi-proxy/client/groups/smb/v1
 github.com/kubernetes-csi/csi-proxy/client/groups/system/v1alpha1
 github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1
 github.com/kubernetes-csi/csi-proxy/client/groups/volume/v1alpha1
-# github.com/pkg/errors v0.8.1
+# github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

There are two scenarios that we might see while deploying the CSI proxy:

- PD CSI driver imports the v1 CSI Proxy client, the node has the beta CSI Proxy server
- PD CSI driver imports the v1 CSI Proxy client, the node has the v1 CSI Proxy server

Instead of handling multiple imports in PD CSI driver we can just use the v1 client with additional startup code to identify which of these cases should attempt to solve.

This PR adds another way to initialize a client by sending a named pipe, the idea is that the user of the client can import the v1 client and still be able to call the v1beta named pipes for compatibility

The client is: 

```
func NewClientWithPipePath(pipePath string) (*Client, error)
```

The consumers of the client should send the `pipePath` they want to use, for example GCE PD CSI driver is using the following:

```golang
import (
	csiproxyclient "github.com/kubernetes-csi/csi-proxy/client"
	"github.com/kubernetes-csi/csi-proxy/client/apiversion"

	diskapi "github.com/kubernetes-csi/csi-proxy/client/api/disk/v1"
	diskclient "github.com/kubernetes-csi/csi-proxy/client/groups/disk/v1"
)

func getDiskClient() (*diskclient.Client, error) {
	var err error
	versionv1beta2 := apiversion.NewVersionOrPanic("v1beta2")
	diskAPIVersions := []apiversion.Version{diskClient.Version /* v1 */, versionv1beta2}

	// attempt to connect to one of the clients in order
	for _, apiVersion := range diskAPIVersions {
		pipePath := csiproxyclient.PipePath(diskclient.GroupName, apiVersion)
		klog.V(4).Infof("Attempting to connect to csi-proxy diskapi at path=%s", pipePath)
		diskClient, err := diskclient.NewClientWithPipePath(pipePath)
		if err == nil {
			klog.V(4).Infof("Connected to csi-proxy diskapi at path=%s", pipePath)
			return diskClient, nil
		}
		klog.V(4).Infof("Connection to csi-proxy diskapi at path=%s failed with error %v, might retry with a different version", pipePath, err)
	}
	return nil, fmt.Errorf("Couldn't connect to any csi-proxy diskapi server, last error %v", err)
}

func NewCSIProxyMounter() (*CSIProxyMounter, error) {
	diskClient, err := getDiskClient()
	if err != nil {
		return nil, err
	}

	fsClient, err := fsclient.NewClient()
	if err != nil {
		return nil, err
	}
	volumeClient, err := volumeclient.NewClient()
	if err != nil {
		return nil, err
	}
	return &CSIProxyMounter{
		FsClient:     fsClient,
		DiskClient:   diskClient,
		VolumeClient: volumeClient,
	}, nil
}
```

In my cluster I have CSI Proxy server v0.2, I've deployed GCE PD CSI driver with the v1 client (this change) and it could successfully avoid connecting to the v1 api because it doesn't exist, the logs:


```
I0407 05:51:58.024148    4288 safe-mounter_windows.go:63] Attempting to connect to csi-proxy diskapi at path=\\.\\pipe\\csi-proxy-disk-v1
I0407 05:51:58.024148    4288 safe-mounter_windows.go:69] Connection to csi-proxy diskapi at path=\\.\\pipe\\csi-proxy-disk-v1 failed with error=open \\.\\pipe\\csi-proxy-disk-v1: The system cannot find the file specified., might retry with a different version
I0407 05:51:58.025117    4288 safe-mounter_windows.go:63] Attempting to connect to csi-proxy diskapi at path=\\.\\pipe\\csi-proxy-disk-v1beta2
I0407 05:51:58.025117    4288 safe-mounter_windows.go:66] Connected to csi-proxy diskapi at path=\\.\\pipe\\csi-proxy-disk-v1beta2
I0407 05:51:58.025117    4288 safe-mounter_windows.go:81] Attempting to connect to csi-proxy fsapi at path=\\.\\pipe\\csi-proxy-filesystem-v1
I0407 05:51:58.025117    4288 safe-mounter_windows.go:87] Connection to csi-proxy fsapi at path=\\.\\pipe\\csi-proxy-filesystem-v1 failed with error=open \\.\\pipe\\csi-proxy-filesystem-v1: The system cannot find the file specified., might retry with a different version
I0407 05:51:58.025117    4288 safe-mounter_windows.go:81] Attempting to connect to csi-proxy fsapi at path=\\.\\pipe\\csi-proxy-filesystem-v1beta1
I0407 05:51:58.026099    4288 safe-mounter_windows.go:84] Connected to csi-proxy fsapi at path=\\.\\pipe\\csi-proxy-filesystem-v1beta1
I0407 05:51:58.026099    4288 safe-mounter_windows.go:99] Attempting to connect to csi-proxy volumeapi at path=\\.\\pipe\\csi-proxy-volume-v1
I0407 05:51:58.026099    4288 safe-mounter_windows.go:105] Connection to csi-proxy volumeapi at path=\\.\\pipe\\csi-proxy-volume-v1 failed with error=open \\.\\pipe\\csi-proxy-volume-v1: The system cannot find the file specified., might retry with a different version
I0407 05:51:58.026099    4288 safe-mounter_windows.go:99] Attempting to connect to csi-proxy volumeapi at path=\\.\\pipe\\csi-proxy-volume-v1beta1
I0407 05:51:58.026099    4288 safe-mounter_windows.go:102] Connected to csi-proxy volumeapi at path=\\.\\pipe\\csi-proxy-volume-v1beta1

```

Edit:

Even though I could connect to the v1beta API using the v1 client I couldn't send a message to it, the error I got was:

```
gce-pd-driver I0407 19:48:16.583101    8696 utils.go:60] /csi.v1.Node/NodeUnstageVolume called with request: volume_id:"projects/UNSPECIFIED/zones/us-central1-b/disks/pvc-1190e7da-72f1-480f-8c9d-95209b061660" staging_target_path:"\\var\\lib\\kubelet\\pl
 ugins\\kubernetes.io\\csi\\volumeDevices\\staging\\pvc-1190e7da-72f1-480f-8c9d-95209b061660"
 gce-pd-driver E0407 19:48:16.584111    8696 utils.go:63] /csi.v1.Node/NodeUnstageVolume returned with error: rpc error: code = Internal desc = NodeUnstageVolume failed: rpc error: code = Unimplemented desc = unknown service v1.Filesystem
```

In PD CSI we are falling back to using both APIs at the same time, in any case, the check with `winio.Dial` works :)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @jingxu97 
