### PR TITLE
Make GPT the new partition style for volumes. Normalize windows paths in SMB apis to support linux style paths in source.

### DIFF
--- a/integrationtests/volume_test.go
+++ b/integrationtests/volume_test.go
@@ -56,7 +56,7 @@ func diskInit(t *testing.T, vhdxPath, mountPath, testPluginPath string) string {
 	var cmd, out string
 	var err error
 	const initialSize = 5 * 1024 * 1024 * 1024
-	const partitionStyle = "MBR"
+	const partitionStyle = "GPT"
 
 	cmd = fmt.Sprintf("mkdir %s", mountPath)
 	if out, err = runPowershellCmd(cmd); err != nil {

--- a/internal/os/disk/api.go
+++ b/internal/os/disk/api.go
@@ -109,7 +109,7 @@ func (APIImplementor) IsDiskInitialized(diskID string) (bool, error) {
 }
 
 func (APIImplementor) InitializeDisk(diskID string) error {
-	cmd := fmt.Sprintf("Initialize-Disk -Number %s -PartitionStyle MBR", diskID)
+	cmd := fmt.Sprintf("Initialize-Disk -Number %s -PartitionStyle GPT", diskID)
 	out, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error initializing disk %s: %v, %v", diskID, out, err)

--- a/internal/server/smb/server.go
+++ b/internal/server/smb/server.go
@@ -3,11 +3,11 @@ package smb
 import (
 	"context"
 	"fmt"
-
 	"github.com/kubernetes-csi/csi-proxy/client/apiversion"
 	fsserver "github.com/kubernetes-csi/csi-proxy/internal/server/filesystem"
 	"github.com/kubernetes-csi/csi-proxy/internal/server/smb/internal"
 	"k8s.io/klog/v2"
+	"strings"
 )
 
 type Server struct {
@@ -22,6 +22,11 @@ type API interface {
 	RemoveSmbGlobalMapping(remotePath string) error
 }
 
+func normalizeWindowsPath(path string) string {
+	normalizedPath := strings.Replace(path, "/", "\\", -1)
+	return normalizedPath
+}
+
 func NewServer(hostAPI API, fsServer *fsserver.Server) (*Server, error) {
 	return &Server{
 		hostAPI:  hostAPI,
@@ -32,7 +37,7 @@ func NewServer(hostAPI API, fsServer *fsserver.Server) (*Server, error) {
 func (s *Server) NewSmbGlobalMapping(context context.Context, request *internal.NewSmbGlobalMappingRequest, version apiversion.Version) (*internal.NewSmbGlobalMappingResponse, error) {
 	klog.V(4).Infof("calling NewSmbGlobalMapping with remote path %q", request.RemotePath)
 	response := &internal.NewSmbGlobalMappingResponse{}
-	remotePath := request.RemotePath
+	remotePath := normalizeWindowsPath(request.RemotePath)
 	localPath := request.LocalPath
 
 	if remotePath == "" {
@@ -90,7 +95,7 @@ func (s *Server) NewSmbGlobalMapping(context context.Context, request *internal.
 func (s *Server) RemoveSmbGlobalMapping(context context.Context, request *internal.RemoveSmbGlobalMappingRequest, version apiversion.Version) (*internal.RemoveSmbGlobalMappingResponse, error) {
 	klog.V(4).Infof("calling RemoveSmbGlobalMapping with remote path %q", request.RemotePath)
 	response := &internal.RemoveSmbGlobalMappingResponse{}
-	remotePath := request.RemotePath
+	remotePath := normalizeWindowsPath(request.RemotePath)
 
 	if remotePath == "" {
 		klog.Errorf("remote path is empty")


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
>
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes an issue where a storage class created with a linux style path does not work for the csi-smb driver due to a mismatch in the slashes.

i.e. if a request comes with the following path //linux/stylepath it will map accordingly the first time, however if a second volume is attempted to be created mounted with the same path the call to IsSmbMapped returns false if the "/" are not changed for "\\". What this pr does is normalize the remotePath received in the request to Windows, regardless of the direction of the slashes

Changes the partition style to explicitly set GPT instead of MBR

**Special notes for your reviewer**:

Included the change of partition type to GPT and updated the test.

**Does this PR introduce a user-facing change?**:

No

```release-note
Make GPT the new partition style for volumes. Normalize windows paths in SMB apis to support linux style paths in source.
```
