### PR TITLE
Don't count reserved partitions (gpt) when checking if any exist

### DIFF
--- a/internal/os/disk/api.go
+++ b/internal/os/disk/api.go
@@ -33,10 +33,10 @@ type API interface {
 	IsDiskInitialized(diskNumber uint32) (bool, error)
 	// InitializeDisk initializes the disk `diskNumber`
 	InitializeDisk(diskNumber uint32) error
-	// PartitionsExist checks if the disk `diskNumber` has any partitions.
-	PartitionsExist(diskNumber uint32) (bool, error)
-	// CreatePartitoin creates a partition in disk `diskNumber`
-	CreatePartition(diskNumber uint32) error
+	// BasicPartitionsExist checks if the disk `diskNumber` has any basic partitions.
+	BasicPartitionsExist(diskNumber uint32) (bool, error)
+	// CreateBasicPartition creates a partition in disk `diskNumber`
+	CreateBasicPartition(diskNumber uint32) error
 	// Rescan updates the host storage cache (re-enumerates disk, partition and volume objects)
 	Rescan() error
 	// GetDiskNumberByName gets a disk number by page83 ID (disk name)
@@ -157,8 +157,8 @@ func (DiskAPI) InitializeDisk(diskNumber uint32) error {
 	return nil
 }
 
-func (DiskAPI) PartitionsExist(diskNumber uint32) (bool, error) {
-	cmd := fmt.Sprintf("Get-Partition | Where DiskNumber -eq %d", diskNumber)
+func (DiskAPI) BasicPartitionsExist(diskNumber uint32) (bool, error) {
+	cmd := fmt.Sprintf("Get-Partition | Where DiskNumber -eq %d | Where Type -eq Basic", diskNumber)
 	out, err := runExec(cmd)
 	if err != nil {
 		return false, fmt.Errorf("error checking presence of partitions on disk %d: %v, %v", diskNumber, out, err)
@@ -170,7 +170,7 @@ func (DiskAPI) PartitionsExist(diskNumber uint32) (bool, error) {
 	return false, nil
 }
 
-func (DiskAPI) CreatePartition(diskNumber uint32) error {
+func (DiskAPI) CreateBasicPartition(diskNumber uint32) error {
 	cmd := fmt.Sprintf("New-Partition -DiskNumber %d -UseMaximumSize", diskNumber)
 	out, err := runExec(cmd)
 	if err != nil {

--- a/internal/server/disk/server.go
+++ b/internal/server/disk/server.go
@@ -66,17 +66,17 @@ func (s *Server) PartitionDisk(context context.Context, request *internal.Partit
 		klog.V(4).Infof("Disk %d already initialized", diskNumber)
 	}
 
-	klog.V(4).Infof("Checking if disk %d is partitioned", diskNumber)
-	partitioned, err := s.hostAPI.PartitionsExist(diskNumber)
+	klog.V(4).Infof("Checking if disk %d has basic partitions", diskNumber)
+	partitioned, err := s.hostAPI.BasicPartitionsExist(diskNumber)
 	if err != nil {
-		klog.Errorf("failed check PartitionsExist %v", err)
+		klog.Errorf("failed check BasicPartitionsExist %v", err)
 		return response, err
 	}
 	if !partitioned {
-		klog.V(4).Infof("Creating partition on disk %d", diskNumber)
-		err = s.hostAPI.CreatePartition(diskNumber)
+		klog.V(4).Infof("Creating basic partition on disk %d", diskNumber)
+		err = s.hostAPI.CreateBasicPartition(diskNumber)
 		if err != nil {
-			klog.Errorf("failed CreatePartition %v", err)
+			klog.Errorf("failed CreateBasicPartition %v", err)
 			return response, err
 		}
 	} else {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:  see https://github.com/kubernetes-csi/csi-proxy/issues/144: with gpt being default, there is some 128MB reserved partition at beginning of disk. LIke
```
PartitionNumber  DriveLetter Offset                                        Size Type
---------------  ----------- ------                                        ---- ----
1                            1048576                                     128 MB Reserved
2                            135266304                                 19.87 GB Basic
```
Don't count it when checking if partition exists.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #144

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
