### PR TITLE
Combine plugin and pod paths into one KubeletPath

### DIFF
--- a/cmd/csi-proxy/main.go
+++ b/cmd/csi-proxy/main.go
@@ -23,10 +23,9 @@ import (
 )
 
 var (
-	kubeletCSIPluginsPath = flag.String("kubelet-csi-plugins-path", `C:\var\lib\kubelet`, "Prefix path of the Kubelet plugin directory in the host file system")
-	kubeletPodPath        = flag.String("kubelet-pod-path", `C:\var\lib\kubelet`, "Prefix path of the kubelet pod directory in the host file system")
-	windowsSvc            = flag.Bool("windows-service", false, "Configure as a Windows Service")
-	service               *handler
+	kubeletPath = flag.String("kubelet-path", `C:\var\lib\kubelet`, "Prefix path of the kubelet directory in the host file system")
+	windowsSvc  = flag.Bool("windows-service", false, "Configure as a Windows Service")
+	service     *handler
 )
 
 type handler struct {
@@ -61,7 +60,7 @@ func main() {
 
 // apiGroups returns the list of enabled API groups.
 func apiGroups() ([]srvtypes.APIGroup, error) {
-	fssrv, err := filesystemsrv.NewServer(*kubeletCSIPluginsPath, *kubeletPodPath, filesystemapi.New())
+	fssrv, err := filesystemsrv.NewServer(*kubeletPath, filesystemapi.New())
 	if err != nil {
 		return []srvtypes.APIGroup{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ replace (
 
 require (
 	github.com/Microsoft/go-winio v0.4.16
+	github.com/golang/protobuf v1.4.1
+	//	github.com/golang/protobuf v1.4.1
 	github.com/google/go-cmp v0.5.0
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/kubernetes-csi/csi-proxy/client v0.0.0-00010101000000-000000000000

--- a/internal/server/filesystem/server_test.go
+++ b/internal/server/filesystem/server_test.go
@@ -41,104 +41,90 @@ func TestMkdirWindows(t *testing.T) {
 	testCases := []struct {
 		name        string
 		path        string
-		pathCtx     internal.PathContext
 		version     apiversion.Version
 		expectError bool
 	}{
 		{
 			name:        "path outside of pod context with pod context set",
 			path:        `C:\foo\bar`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path inside pod context with pod context set",
 			path:        `C:\var\lib\kubelet\pods\pv1`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: false,
 		},
 		{
 			name:        "path outside of plugin context with plugin context set",
 			path:        `C:\foo\bar`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path inside plugin context with plugin context set",
 			path:        `C:\var\lib\kubelet\plugins\pv1`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: false,
 		},
 		{
 			name:        "path with invalid character `:` beyond drive letter prefix",
 			path:        `C:\var\lib\kubelet\plugins\csi-plugin\pv1:foo`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid character `/`",
 			path:        `C:\var\lib\kubelet\pods\pv1/foo`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid character `*`",
 			path:        `C:\var\lib\kubelet\plugins\csi-plugin\pv1*foo`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid character `?`",
 			path:        `C:\var\lib\kubelet\pods\pv1?foo`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid character `|`",
 			path:        `C:\var\lib\kubelet\plugins\csi-plugin|pv1\foo`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid characters `..`",
 			path:        `C:\var\lib\kubelet\pods\pv1\..\..\..\system32`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid prefix `\\`",
 			path:        `\\csi-plugin\..\..\..\system32`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "relative path",
 			path:        `pv1\foo`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 	}
-	srv, err := NewServer(`C:\var\lib\kubelet\plugins`, `C:\var\lib\kubelet\pods`, &fakeFileSystemAPI{})
+	srv, err := NewServer(`C:\var\lib\kubelet`, &fakeFileSystemAPI{})
 	if err != nil {
 		t.Fatalf("FileSystem Server could not be initialized for testing: %v", err)
 	}
 	for _, tc := range testCases {
 		t.Logf("test case: %s", tc.name)
 		req := &internal.MkdirRequest{
-			Path:    tc.path,
-			Context: tc.pathCtx,
+			Path: tc.path,
 		}
 		_, err := srv.Mkdir(context.TODO(), req, tc.version)
 		if tc.expectError && err == nil {
@@ -158,7 +144,6 @@ func TestRmdirWindows(t *testing.T) {
 	testCases := []struct {
 		name        string
 		path        string
-		pathCtx     internal.PathContext
 		version     apiversion.Version
 		expectError bool
 		force       bool
@@ -166,98 +151,85 @@ func TestRmdirWindows(t *testing.T) {
 		{
 			name:        "path outside of pod context with pod context set",
 			path:        `C:\foo\bar`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path inside pod context with pod context set",
 			path:        `C:\var\lib\kubelet\pods\pv1`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: false,
 		},
 		{
 			name:        "path outside of plugin context with plugin context set",
 			path:        `C:\foo\bar`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path inside plugin context with plugin context set",
 			path:        `C:\var\lib\kubelet\plugins\pv1`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: false,
 		},
 		{
 			name:        "path with invalid character `:` beyond drive letter prefix",
 			path:        `C:\var\lib\kubelet\plugins\csi-plugin\pv1:foo`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid character `/`",
 			path:        `C:\var\lib\kubelet\pods\pv1/foo`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid character `*`",
 			path:        `C:\var\lib\kubelet\plugins\csi-plugin\pv1*foo`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid character `?`",
 			path:        `C:\var\lib\kubelet\pods\pv1?foo`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid character `|`",
 			path:        `C:\var\lib\kubelet\plugins\csi-plugin|pv1\foo`,
-			pathCtx:     internal.PLUGIN,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid characters `..`",
 			path:        `C:\var\lib\kubelet\pods\pv1\..\..\..\system32`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "path with invalid prefix `\\`",
 			path:        `\\csi-plugin\..\..\..\system32`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 		{
 			name:        "relative path",
 			path:        `pv1\foo`,
-			pathCtx:     internal.POD,
 			version:     v1,
 			expectError: true,
 		},
 	}
-	srv, err := NewServer(`C:\var\lib\kubelet\plugins`, `C:\var\lib\kubelet\pods`, &fakeFileSystemAPI{})
+	srv, err := NewServer(`C:\var\lib\kubelet`, &fakeFileSystemAPI{})
 	if err != nil {
 		t.Fatalf("FileSystem Server could not be initialized for testing: %v", err)
 	}
 	for _, tc := range testCases {
 		t.Logf("test case: %s", tc.name)
 		req := &internal.RmdirRequest{
-			Path:    tc.path,
-			Context: tc.pathCtx,
-			Force:   tc.force,
+			Path:  tc.path,
+			Force: tc.force,
 		}
 		_, err := srv.Rmdir(context.TODO(), req, tc.version)
 		if tc.expectError && err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/Microsoft/go-winio/pkg/guid
 github.com/davecgh/go-spew/spew
 # github.com/go-logr/logr v0.2.0
 github.com/go-logr/logr
-# github.com/golang/protobuf v1.4.1
+github.com/golang/protobuf v1.4.1
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any


### PR DESCRIPTION
Instead of using pod and plugin paths, comebine them into one
kubeletPath option

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
