### PR TITLE
Update references to old cli args in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ If you are using kube-up to start a Windows cluster, node startup script will au
 
 ### Command line options
 
-* `--kubelet-csi-plugins-path`: This is the prefix path of the Kubelet plugin directory in the host file system (`C:\var\lib\kubelet` is used by default).
-
-* `--kubelet-pod-path`: This is the prefix path of the kubelet pod directory in the host file system (`C:\var\lib\kubelet` is used by default).
+* `--kubelet-path`: This is the prefix path of the kubelet path directory in the host file system (`C:\var\lib\kubelet` is used by default).
 
 ### Setup for CSI Driver Deployment
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -113,7 +113,7 @@ git fetch; git pull --rebase origin $BRANCH
 
 # terminal 1 (build and start CSI proxy)
 go build -v -a -o ./bin/csi-proxy.exe ./cmd/csi-proxy
-.\bin\csi-proxy.exe --kubelet-csi-plugins-path $pwd --kubelet-pod-path $pwd --v=5
+.\bin\csi-proxy.exe --v=5
 
 # terminal 2 (run E2E tests)
 go test -v .\integrationtests\ -run TestVolumeAPIs

--- a/scripts/e2e-runner.ps1
+++ b/scripts/e2e-runner.ps1
@@ -36,7 +36,7 @@ go build -v -a -o ./build/csi-proxy-api-gen ./cmd/csi-proxy-api-gen
 Write-Output "starting csi-proxy"
 $csiproxy = Start-Job -Name CSIProxy -ScriptBlock {
     cd $HOME/go/src/github.com/kubernetes-csi/csi-proxy
-    .\bin\csi-proxy.exe --kubelet-csi-plugins-path $pwd --kubelet-pod-path $pwd --v=5
+    .\bin\csi-proxy.exe --v=5
 };
 Start-Sleep -Seconds 10;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind documentation

**What this PR does / why we need it**:

Removes references in the documentation to the old cli args to use `--kubelet-path` instead.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/cc @jingxu97 @ddebroy 