### PR TITLE
cloud build: create work directory

### DIFF
--- a/.cloudbuild.sh
+++ b/.cloudbuild.sh
@@ -5,5 +5,8 @@
 # Extract tag-n-hash value from GIT_TAG (form vYYYYMMDD-tag-n-hash) for REV value.
 REV=v$(echo "$GIT_TAG" | cut -f3- -d 'v')
 
+# This creates the CSI_PROW_WORK directory that is needed by run_with_go.
+ensure_paths
+
 run_with_go "${CSI_PROW_GO_VERSION_BUILD}" make build REV="${REV}"
 cp bin/csi-proxy.exe bin/csi-proxy-"${PULL_BASE_REF}".exe


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This fixes the following cloud build failure:
```
  tests that need to be skipped: CSI_PROW_E2E_SKIP=Disruptive
  tar: can't change directory to '': No such file or directory
  Thu Jun 17 17:15:10 UTC 2021 go1.13.5 $ curl --fail --location https://dl.google.com/go/go1.16.linux-amd64.tar.gz
  ...
  curl: (23) Failed writing body (0 != 1377)
  ERROR: installation of Go 1.16 failed
  ERROR
  ERROR: build step 0 "gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8" failed: step exited with non-zero status: 1
```
It's necessary because of https://github.com/kubernetes-csi/csi-release-tools/commit/6880b0c80d2c43187c8d0ce3ff61c9517a56d34d

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
