### PR TITLE
Add Docs for v1 APIs

### DIFF
--- a/docs/apis/disk_v1.md
+++ b/docs/apis/disk_v1.md
@@ -1,0 +1,148 @@
+# CSI Proxy Disk v1 API
+<a name="top"></a>
+
+## Table of Contents
+
+- [Disk RPCs](#v1.DiskRPCs)
+
+- [Disk Messages](#v1.DiskMessages)
+
+
+<a name="v1.DiskRPCs"></a>
+## v1 Disk RPCs
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| ListDiskLocations | [ListDiskLocationsRequest](#v1.ListDiskLocationsRequest) | [ListDiskLocationsResponse](#v1.ListDiskLocationsResponse) | ListDiskLocations returns locations &lt;Adapter, Bus, Target, LUN ID&gt; of all disk devices enumerated by the host. |
+| PartitionDisk | [PartitionDiskRequest](#v1.PartitionDiskRequest) | [PartitionDiskResponse](#v1.PartitionDiskResponse) | PartitionDisk initializes and partitions a disk device with the GPT partition style (if the disk has not been partitioned already) and returns the resulting volume device ID. |
+| Rescan | [RescanRequest](#v1.RescanRequest) | [RescanResponse](#v1.RescanResponse) | Rescan refreshes the host&#39;s storage cache. |
+| ListDiskIDs | [ListDiskIDsRequest](#v1.ListDiskIDsRequest) | [ListDiskIDsResponse](#v1.ListDiskIDsResponse) | ListDiskIDs returns a map of DiskID objects where the key is the disk number. |
+| GetDiskStats | [GetDiskStatsRequest](#v1.GetDiskStatsRequest) | [GetDiskStatsResponse](#v1.GetDiskStatsResponse) | GetDiskStats returns the stats of a disk (currently it returns the disk size). |
+| SetDiskState | [SetDiskStateRequest](#v1.SetDiskStateRequest) | [SetDiskStateResponse](#v1.SetDiskStateResponse) | SetDiskState sets the offline/online state of a disk. |
+| GetDiskState | [GetDiskStateRequest](#v1.GetDiskStateRequest) | [GetDiskStateResponse](#v1.GetDiskStateResponse) | GetDiskState gets the offline/online state of a disk. |
+
+
+<a name="v1.DiskMessages"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## v1 Disk Messages
+
+<a name="v1.DiskIDs"></a>
+### DiskIDs
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| page83 | string |  | The disk page83 id. |
+| serial_number | string |  | The disk serial number. |
+
+<a name="v1.DiskLocation"></a>
+### DiskLocation
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| Adapter | string |  |  |
+| Bus | string |  |  |
+| Target | string |  |  |
+| LUNID | string |  |  |
+
+<a name="v1.GetDiskStateRequest"></a>
+### GetDiskStateRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disk_number | uint32 |  | Disk device number of the disk. |
+
+<a name="v1.GetDiskStateResponse"></a>
+### GetDiskStateResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| is_online | bool |  | Online state of the disk. true for online, false for offline. |
+
+<a name="v1.GetDiskStatsRequest"></a>
+### GetDiskStatsRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disk_number | uint32 |  | Disk device number of the disk to get the stats from. |
+
+<a name="v1.GetDiskStatsResponse"></a>
+### GetDiskStatsResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| total_bytes | int64 |  | Total size of the volume. |
+
+<a name="v1.ListDiskIDsRequest"></a>
+
+### ListDiskIDsRequest
+Intentionally empty.
+
+<a name="v1.ListDiskIDsResponse"></a>
+### ListDiskIDsResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| diskIDs | [ListDiskIDsResponse.DiskIDsEntry](#v1.ListDiskIDsResponse.DiskIDsEntry) | repeated | Map of disk numbers and disk identifiers associated with each disk device.
+
+the case is intentional for protoc to generate the field as DiskIDs |
+
+<a name="v1.ListDiskIDsResponse.DiskIDsEntry"></a>
+### ListDiskIDsResponse.DiskIDsEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | uint32 |  |  |
+| value | [DiskIDs](#v1.DiskIDs) |  |  |
+
+<a name="v1.ListDiskLocationsRequest"></a>
+
+### ListDiskLocationsRequest
+Intentionally empty.
+
+<a name="v1.ListDiskLocationsResponse"></a>
+### ListDiskLocationsResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disk_locations | [ListDiskLocationsResponse.DiskLocationsEntry](#v1.ListDiskLocationsResponse.DiskLocationsEntry) | repeated | Map of disk number and &lt;adapter, bus, target, lun ID&gt; associated with each disk device. |
+
+<a name="v1.ListDiskLocationsResponse.DiskLocationsEntry"></a>
+### ListDiskLocationsResponse.DiskLocationsEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | uint32 |  |  |
+| value | [DiskLocation](#v1.DiskLocation) |  |  |
+
+<a name="v1.PartitionDiskRequest"></a>
+### PartitionDiskRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disk_number | uint32 |  | Disk device number of the disk to partition. |
+
+<a name="v1.PartitionDiskResponse"></a>
+### PartitionDiskResponse
+Intentionally empty.
+
+<a name="v1.RescanRequest"></a>
+### RescanRequest
+Intentionally empty.
+
+<a name="v1.RescanResponse"></a>
+
+### RescanResponse
+Intentionally empty.
+
+<a name="v1.SetDiskStateRequest"></a>
+### SetDiskStateRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disk_number | uint32 |  | Disk device number of the disk. |
+| is_online | bool |  | Online state to set for the disk. true for online, false for offline. |
+
+<a name="v1.SetDiskStateResponse"></a>
+### SetDiskStateResponse
+Intentionally empty.

--- a/docs/apis/filesystem_v1.md
+++ b/docs/apis/filesystem_v1.md
@@ -1,0 +1,97 @@
+# CSI Proxy FileSystem v1 API
+<a name="top"></a>
+
+## Table of Contents
+
+- [FileSystem RPCs](#v1.FileSystemRPCs)
+
+- [FileSystem Messages](#v1.FileSystemMessages)
+
+
+<a name="v1.FileSystemRPCs"></a>
+
+## v1 FileSystem RPCs
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| PathExists | [PathExistsRequest](#v1.PathExistsRequest) | [PathExistsResponse](#v1.PathExistsResponse) | PathExists checks if the requested path exists in the host filesystem. |
+| Mkdir | [MkdirRequest](#v1.MkdirRequest) | [MkdirResponse](#v1.MkdirResponse) | Mkdir creates a directory at the requested path in the host filesystem. |
+| Rmdir | [RmdirRequest](#v1.RmdirRequest) | [RmdirResponse](#v1.RmdirResponse) | Rmdir removes the directory at the requested path in the host filesystem. This may be used for unlinking a symlink created through CreateSymlink. |
+| CreateSymlink | [CreateSymlinkRequest](#v1.CreateSymlinkRequest) | [CreateSymlinkResponse](#v1.CreateSymlinkResponse) | CreateSymlink creates a symbolic link called target_path that points to source_path in the host filesystem (target_path is the name of the symbolic link created, source_path is the existing path). |
+| IsSymlink | [IsSymlinkRequest](#v1.IsSymlinkRequest) | [IsSymlinkResponse](#v1.IsSymlinkResponse) | IsSymlink checks if a given path is a symlink. |
+
+
+<a name="v1.FileSystemMessages"></a>
+<p align="right"><a href="#top">Top</a></p>
+## v1 FileSystem Messages
+
+<a name="v1.CreateSymlinkRequest"></a>
+### CreateSymlinkRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| source_path | string |  | The path of the existing directory to be linked. All special characters allowed by Windows in path names will be allowed except for restrictions noted below. For details, please check: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+| target_path | string |  | Target path is the location of the new directory entry to be created in the host's filesystem. All special characters allowed by Windows in path names will be allowed except for restrictions noted below. For details, please check: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+
+
+Restrictions: Only absolute path (indicated by a drive letter prefix: e.g. &#34;C:\&#34;) is accepted. The path prefix needs needs to match the paths specified as kubelet-path parameter of csi-proxy. UNC paths of the form &#34;\\server\share\path\file&#34; are not allowed. All directory separators need to be backslash character: &#34;\&#34;. Characters: .. / : | ? * in the path are not allowed. source_path cannot already exist in the host filesystem. Maximum path length will be capped to 260 characters.
+
+<a name="v1.CreateSymlinkResponse"></a>
+### CreateSymlinkResponse
+Intentionally empty.
+
+<a name="v1.IsSymlinkRequest"></a>
+### IsSymlinkRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| path | string |  | The path whose existence as a symlink we want to check in the host&#39;s filesystem. |
+
+
+<a name="v1.IsSymlinkResponse"></a>
+### IsSymlinkResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| is_symlink | bool |  | Indicates whether the path in IsSymlinkRequest is a symlink. |
+
+<a name="v1.MkdirRequest"></a>
+### MkdirRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| path | string |  | The path to create in the host&#39;s filesystem. All special characters allowed by Windows in path names will be allowed except for restrictions noted below. For details, please check: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file Non-existent parent directories in the path will be automatically created. Directories will be created with Read and Write privileges of the Windows User account under which csi-proxy is started (typically LocalSystem).
+
+Restrictions: Only absolute path (indicated by a drive letter prefix: e.g. &#34;C:\&#34;) is accepted. Depending on the context parameter of this function, the path prefix needs to match the paths specified either as kubelet-csi-plugins-path or as kubelet-pod-path parameters of csi-proxy. The path parameter cannot already exist in the host&#39;s filesystem. UNC paths of the form &#34;\\server\share\path\file&#34; are not allowed. All directory separators need to be backslash character: &#34;\&#34;. Characters: .. / : | ? * in the path are not allowed. Maximum path length will be capped to 260 characters.
+
+<a name="v1.MkdirResponse"></a>
+### MkdirResponse
+Intentionally empty.
+
+<a name="v1.PathExistsRequest"></a>
+### PathExistsRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| path | string |  | The path whose existence we want to check in the host&#39;s filesystem |
+
+<a name="v1.PathExistsResponse"></a>
+### PathExistsResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| exists | bool |  | Indicates whether the path in PathExistsRequest exists in the host&#39;s filesystem |
+
+<a name="v1.RmdirRequest"></a>
+### RmdirRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| path | string |  | The path to remove in the host&#39;s filesystem. All special characters allowed by Windows in path names will be allowed except for restrictions noted below. For details, please check: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+| force | bool |  | Force remove all contents under path (if any). |
+
+Restrictions: Only absolute path (indicated by a drive letter prefix: e.g. &#34;C:\&#34;) is accepted. Depending on the context parameter of this function, the path prefix needs to match the paths specified either as kubelet-csi-plugins-path or as kubelet-pod-path parameters of csi-proxy. UNC paths of the form &#34;\\server\share\path\file&#34; are not allowed. All directory separators need to be backslash character: &#34;\&#34;. Characters: .. / : | ? * in the path are not allowed. Path cannot be a file of type symlink. Maximum path length will be capped to 260 characters.
+
+<a name="v1.RmdirResponse"></a>
+### RmdirResponse
+Intentionally empty.

--- a/docs/apis/smb_v1.md
+++ b/docs/apis/smb_v1.md
@@ -1,0 +1,54 @@
+# CSI Proxy SMB v1 API
+<a name="top"></a>
+
+## Table of Contents
+
+- [SMB RPCs](#v1.SMBRPCs)
+
+- [SMB Messages](#v1.SMBMessages)
+
+
+<a name="v1.SMBRPCs"></a>
+
+## v1 SMB RPCs
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| NewSmbGlobalMapping | [NewSmbGlobalMappingRequest](#v1.NewSmbGlobalMappingRequest) | [NewSmbGlobalMappingResponse](#v1.NewSmbGlobalMappingResponse) | NewSmbGlobalMapping creates an SMB mapping on the SMB client to an SMB share. |
+| RemoveSmbGlobalMapping | [RemoveSmbGlobalMappingRequest](#v1.RemoveSmbGlobalMappingRequest) | [RemoveSmbGlobalMappingResponse](#v1.RemoveSmbGlobalMappingResponse) | RemoveSmbGlobalMapping removes the SMB mapping to an SMB share. |
+
+
+<a name="v1.SMBMessages"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## v1 SMB Messages
+
+<a name="v1.NewSmbGlobalMappingRequest"></a>
+### NewSmbGlobalMappingRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| remote_path | string |  | A remote SMB share to mount All unicode characters allowed in SMB server name specifications are permitted except for restrictions below
+| local_path | string |  | Optional local path to mount the smb on |
+| username | string |  | Username credential associated with the share |
+| password | string |  | Password credential associated with the share |
+
+Restrictions: SMB remote path specified in the format: \\server-name\sharename, \\server.fqdn\sharename or \\a.b.c.d\sharename If not an IP address, share name has to be a valid DNS name. UNC specifications to local paths or prefix: \\?\ is not allowed. Characters: &#43; [ ] &#34; / : ; | &lt; &gt; , ? * = $ are not allowed.
+
+<a name="v1.NewSmbGlobalMappingResponse"></a>
+### NewSmbGlobalMappingResponse
+Intentionally empty.
+
+<a name="v1.RemoveSmbGlobalMappingRequest"></a>
+### RemoveSmbGlobalMappingRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| remote_path | string |  | A remote SMB share mapping to remove All unicode characters allowed in SMB server name specifications are permitted except for restrictions below
+
+Restrictions: SMB share specified in the format: \\server-name\sharename, \\server.fqdn\sharename or \\a.b.c.d\sharename If not an IP address, share name has to be a valid DNS name. UNC specifications to local paths or prefix: \\?\ is not allowed. Characters: &#43; [ ] &#34; / : ; | &lt; &gt; , ? * = $ are not allowed.
+
+<a name="v1.RemoveSmbGlobalMappingResponse"></a>
+
+### RemoveSmbGlobalMappingResponse
+Intentionally empty.

--- a/docs/apis/volume_v1.md
+++ b/docs/apis/volume_v1.md
@@ -1,0 +1,163 @@
+# CSI Proxy Volume v1 API
+<a name="top"></a>
+
+## Table of Contents
+
+- [Volume RPCs](#v1.VolumeRPCs)
+
+- [Volume Messages](#v1.VolumeMessages)
+
+<a name="v1.VolumeRPCs"></a>
+
+## v1 Volume RPCs
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| ListVolumesOnDisk | [ListVolumesOnDiskRequest](#v1.ListVolumesOnDiskRequest) | [ListVolumesOnDiskResponse](#v1.ListVolumesOnDiskResponse) | ListVolumesOnDisk returns the volume IDs (in \\.\Volume{GUID} format) for all volumes from a given disk number and partition number (optional) |
+| MountVolume | [MountVolumeRequest](#v1.MountVolumeRequest) | [MountVolumeResponse](#v1.MountVolumeResponse) | MountVolume mounts the volume at the requested global staging path. |
+| UnmountVolume | [UnmountVolumeRequest](#v1.UnmountVolumeRequest) | [UnmountVolumeResponse](#v1.UnmountVolumeResponse) | UnmountVolume flushes data cache to disk and removes the global staging path. |
+| IsVolumeFormatted | [IsVolumeFormattedRequest](#v1.IsVolumeFormattedRequest) | [IsVolumeFormattedResponse](#v1.IsVolumeFormattedResponse) | IsVolumeFormatted checks if a volume is formatted. |
+| FormatVolume | [FormatVolumeRequest](#v1.FormatVolumeRequest) | [FormatVolumeResponse](#v1.FormatVolumeResponse) | FormatVolume formats a volume with NTFS. |
+| ResizeVolume | [ResizeVolumeRequest](#v1.ResizeVolumeRequest) | [ResizeVolumeResponse](#v1.ResizeVolumeResponse) | ResizeVolume performs resizing of the partition and file system for a block based volume. |
+| GetVolumeStats | [GetVolumeStatsRequest](#v1.GetVolumeStatsRequest) | [GetVolumeStatsResponse](#v1.GetVolumeStatsResponse) | GetVolumeStats gathers total bytes and used bytes for a volume. |
+| GetDiskNumberFromVolumeID | [GetDiskNumberFromVolumeIDRequest](#v1.GetDiskNumberFromVolumeIDRequest) | [GetDiskNumberFromVolumeIDResponse](#v1.GetDiskNumberFromVolumeIDResponse) | GetDiskNumberFromVolumeID gets the disk number of the disk where the volume is located. |
+| GetVolumeIDFromTargetPath | [GetVolumeIDFromTargetPathRequest](#v1.GetVolumeIDFromTargetPathRequest) | [GetVolumeIDFromTargetPathResponse](#v1.GetVolumeIDFromTargetPathResponse) | GetVolumeIDFromTargetPath gets the volume id for a given target path. |
+| WriteVolumeCache | [WriteVolumeCacheRequest](#v1.WriteVolumeCacheRequest) | [WriteVolumeCacheResponse](#v1.WriteVolumeCacheResponse) | WriteVolumeCache write volume cache to disk. |
+
+
+<a name="v1.VolumeMessages"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## v1 Volume Messages
+
+<a name="v1.FormatVolumeRequest"></a>
+### FormatVolumeRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | Volume device ID of the volume to format. |
+
+<a name="v1.FormatVolumeResponse"></a>
+### FormatVolumeResponse
+Intentionally empty.
+
+<a name="v1.GetDiskNumberFromVolumeIDRequest"></a>
+### GetDiskNumberFromVolumeIDRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | Volume device ID of the volume to get the disk number for. |
+
+<a name="v1.GetDiskNumberFromVolumeIDResponse"></a>
+### GetDiskNumberFromVolumeIDResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disk_number | uint32 |  | Corresponding disk number. |
+
+<a name="v1.GetVolumeIDFromTargetPathRequest"></a>
+### GetVolumeIDFromTargetPathRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| target_path | string |  | The target path. |
+
+<a name="v1.GetVolumeIDFromTargetPathResponse"></a>
+### GetVolumeIDFromTargetPathResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | The volume device ID. |
+
+<a name="v1.GetVolumeStatsRequest"></a>
+### GetVolumeStatsRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | Volume device Id of the volume to get the stats for. |
+
+<a name="v1.GetVolumeStatsResponse"></a>
+### GetVolumeStatsResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| total_bytes | int64 |  | Total bytes |
+| used_bytes | int64 |  | Used bytes |
+
+<a name="v1.IsVolumeFormattedRequest"></a>
+### IsVolumeFormattedRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | Volume device ID of the volume to check. |
+
+<a name="v1.IsVolumeFormattedResponse"></a>
+### IsVolumeFormattedResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| formatted | bool |  | Is the volume formatted with NTFS. |
+
+<a name="v1.ListVolumesOnDiskRequest"></a>
+### ListVolumesOnDiskRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disk_number | uint32 |  | Disk device number of the disk to query for volumes. |
+| partition_number | uint32 |  | The partition number (optional), by default it uses the first partition of the disk. |
+
+<a name="v1.ListVolumesOnDiskResponse"></a>
+### ListVolumesOnDiskResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_ids | string | repeated | Volume device IDs of volumes on the specified disk. |
+
+
+<a name="v1.MountVolumeRequest"></a>
+### MountVolumeRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | Volume device ID of the volume to mount. |
+| target_path | string |  | Path in the host&#39;s file system where the volume needs to be mounted. |
+
+<a name="v1.MountVolumeResponse"></a>
+### MountVolumeResponse
+Intentionally empty.
+
+<a name="v1.ResizeVolumeRequest"></a>
+### ResizeVolumeRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | Volume device ID of the volume to resize. |
+| size_bytes | int64 |  | New size in bytes of the volume. |
+
+<a name="v1.ResizeVolumeResponse"></a>
+### ResizeVolumeResponse
+Intentionally empty.
+
+<a name="v1.UnmountVolumeRequest"></a>
+### UnmountVolumeRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | Volume device ID of the volume to dismount. |
+| target_path | string |  | Path where the volume has been mounted. |
+
+<a name="v1.UnmountVolumeResponse"></a>
+### UnmountVolumeResponse
+Intentionally empty.
+
+<a name="v1.WriteVolumeCacheRequest"></a>
+### WriteVolumeCacheRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| volume_id | string |  | Volume device ID of the volume to flush the cache. |
+
+
+<a name="v1.WriteVolumeCacheResponse"></a>
+### WriteVolumeCacheResponse
+Intentionally empty.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation

> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Add more readable documentation for the v1 API groups

**Special notes for your reviewer**:
Docs generated using protoc-gen-doc + some manual fixups to align it with what we want. TODO: make the protoc-gen-doc generate what we want and make that a Makefile target.

```
csi-proxy % docker run --rm -v $(pwd)/docs/apis:/out -v $(pwd)/client/api/smb/v1:/protos pseudomuto/protoc-gen-doc --doc_opt=markdown,smb_v1.md
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
