### PR TITLE
fix: check partition error on MBR disk

### DIFF
--- a/pkg/os/disk/api.go
+++ b/pkg/os/disk/api.go
@@ -158,7 +158,7 @@ func (DiskAPI) InitializeDisk(diskNumber uint32) error {
 }
 
 func (DiskAPI) BasicPartitionsExist(diskNumber uint32) (bool, error) {
-	cmd := fmt.Sprintf("Get-Partition | Where DiskNumber -eq %d | Where Type -eq Basic", diskNumber)
+	cmd := fmt.Sprintf("Get-Partition | Where DiskNumber -eq %d | Where Type -ne Reserved", diskNumber)
 	out, err := runExec(cmd)
 	if err != nil {
 		return false, fmt.Errorf("error checking presence of partitions on disk %d: %v, %v", diskNumber, out, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: check partition error on MBR disk
Before k8s 1.22, all default windows disk type is MBR, and `Type` of `Get-Partition` for MBR disk is `IFS`, PR(https://github.com/kubernetes-csi/csi-proxy/pull/145) brings the breaking change, it would lead to check partition error on MBR disk, this PR only filters `Basic` type which could solve the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/Azure/AKS/issues/2568

**Special notes for your reviewer**:
/assign @wongma7 @jingxu97 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: check partition error on MBR disk
```
