### PR TITLE
Add the --working-dir repeated flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ On successful execution of `make build`, the output binary `csi-proxy.exe` will 
 
 csi-proxy.exe can be installed and run as binary or run as a Windows service on each Windows node. See the following as an example to run CSI Proxy as a web service.
 ```
-    $flags = "-windows-service -log_file=\etc\kubernetes\logs\csi-proxy.log -logtostderr=false"
-    sc.exe create csiproxy binPath= "\etc\kubernetes\node\bin\csi-proxy.exe $flags"
+    $flags = "-windows-service -log_file=C:\etc\kubernetes\logs\csi-proxy.log -logtostderr=false"
+    sc.exe create csiproxy binPath= "C:\etc\kubernetes\node\bin\csi-proxy.exe $flags"
     sc.exe failure csiproxy reset= 0 actions= restart/10000
     sc.exe start csiproxy
 ```
@@ -62,6 +62,7 @@ If you are using kube-up to start a Windows cluster, node startup script will au
 ### Command line options
 
 * `--kubelet-path`: This is the prefix path of the kubelet path directory in the host file system (`C:\var\lib\kubelet` is used by default).
+* `--working-dir` (repeated flag): Prefix path where CSI Proxy is allowed to make privileged operations in the host file system (no value by default).
 
 ### Setup for CSI Driver Deployment
 
@@ -108,6 +109,7 @@ spec:
             - name: registration-dir
               mountPath: C:\registration
         - name: csi-driver
+          # placeholder, use your CSI driver
           image: org/csi-driver:win-v1
           args:
             - "--v=5"

--- a/cmd/csi-proxy/main.go
+++ b/cmd/csi-proxy/main.go
@@ -22,15 +22,31 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type workingDirFlags []string
+
+func (i *workingDirFlags) String() string {
+	return "Not implemented"
+}
+
+func (i *workingDirFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 var (
 	kubeletPath = flag.String("kubelet-path", `C:\var\lib\kubelet`, "Prefix path of the kubelet directory in the host file system")
 	windowsSvc  = flag.Bool("windows-service", false, "Configure as a Windows Service")
 	service     *handler
+	workingDirs workingDirFlags
 )
 
 type handler struct {
 	tosvc   chan bool
 	fromsvc chan error
+}
+
+func init() {
+	flag.Var(&workingDirs, "working-dir", "Prefix path of the csi-proxy working directory in the host file system")
 }
 
 func main() {
@@ -60,7 +76,7 @@ func main() {
 
 // apiGroups returns the list of enabled API groups.
 func apiGroups() ([]srvtypes.APIGroup, error) {
-	fssrv, err := filesystemsrv.NewServer(*kubeletPath, filesystemapi.New())
+	fssrv, err := filesystemsrv.NewServer(*kubeletPath, workingDirs, filesystemapi.New())
 	if err != nil {
 		return []srvtypes.APIGroup{}, err
 	}

--- a/pkg/server/filesystem/server_test.go
+++ b/pkg/server/filesystem/server_test.go
@@ -117,7 +117,7 @@ func TestMkdirWindows(t *testing.T) {
 			expectError: true,
 		},
 	}
-	srv, err := NewServer(`C:\var\lib\kubelet`, &fakeFileSystemAPI{})
+	srv, err := NewServer(`C:\var\lib\kubelet`, []string{}, &fakeFileSystemAPI{})
 	if err != nil {
 		t.Fatalf("FileSystem Server could not be initialized for testing: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestRmdirWindows(t *testing.T) {
 			expectError: true,
 		},
 	}
-	srv, err := NewServer(`C:\var\lib\kubelet`, &fakeFileSystemAPI{})
+	srv, err := NewServer(`C:\var\lib\kubelet`, []string{}, &fakeFileSystemAPI{})
 	if err != nil {
 		t.Fatalf("FileSystem Server could not be initialized for testing: %v", err)
 	}

--- a/pkg/server/smb/server_test.go
+++ b/pkg/server/smb/server_test.go
@@ -83,7 +83,7 @@ func TestNewSmbGlobalMapping(t *testing.T) {
 			expectError: false,
 		},
 	}
-	fsSrv, err := fsserver.NewServer(`C:\var\lib\kubelet`, &fakeFileSystemAPI{})
+	fsSrv, err := fsserver.NewServer(`C:\var\lib\kubelet`, []string{}, &fakeFileSystemAPI{})
 	if err != nil {
 		t.Fatalf("FileSystem Server could not be initialized for testing: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind feature

**What this PR does / why we need it**:
Adds the `--working-dir` flag to allow some privileged operations in paths additional to `--kubelet-path`, for LVP we realized that in Windows we might need to do `Rmdir` and `Mkdir` in paths outside `C:\var\lib\kubelet`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
New `--working-dir` repeated flag, prefix path of the csi-proxy working directory in the host file system, check the README for more information.
```

/cc @jingxu97 @ddebroy 