### PR TITLE
Filesystem server accepts an array of working dirs only, log on startup

### DIFF
--- a/cmd/csi-proxy/main.go
+++ b/cmd/csi-proxy/main.go
@@ -61,14 +61,14 @@ func main() {
 		}
 	}
 
+	klog.Info("Starting CSI-Proxy Server ...")
+	klog.Infof("Version: %s", version)
 	apiGroups, err := apiGroups()
 	if err != nil {
 		panic(err)
 	}
 	s := server.NewServer(apiGroups...)
 
-	klog.Info("Starting CSI-Proxy Server ...")
-	klog.Infof("Version: %s", version)
 	if err := s.Start(nil); err != nil {
 		panic(err)
 	}
@@ -76,10 +76,12 @@ func main() {
 
 // apiGroups returns the list of enabled API groups.
 func apiGroups() ([]srvtypes.APIGroup, error) {
-	fssrv, err := filesystemsrv.NewServer(*kubeletPath, workingDirs, filesystemapi.New())
+	workingDirs = append(workingDirs, *kubeletPath)
+	fssrv, err := filesystemsrv.NewServer(workingDirs, filesystemapi.New())
 	if err != nil {
 		return []srvtypes.APIGroup{}, err
 	}
+	klog.Info("Working directories: %v", fssrv.GetWorkingDirs())
 
 	volumesrv, err := volumesrv.NewServer(volumeapi.New())
 	if err != nil {

--- a/pkg/server/filesystem/server.go
+++ b/pkg/server/filesystem/server.go
@@ -14,7 +14,6 @@ import (
 )
 
 type Server struct {
-	kubeletPath string
 	workingDirs []string
 	hostAPI     filesystem.API
 }
@@ -25,12 +24,15 @@ var _ internal.ServerInterface = &Server{}
 var invalidPathCharsRegexWindows = regexp.MustCompile(`["/\:\?\*|]`)
 var absPathRegexWindows = regexp.MustCompile(`^[a-zA-Z]:\\`)
 
-func NewServer(kubeletPath string, workingDirs []string, hostAPI filesystem.API) (*Server, error) {
+func NewServer(workingDirs []string, hostAPI filesystem.API) (*Server, error) {
 	return &Server{
-		kubeletPath: kubeletPath,
 		workingDirs: workingDirs,
 		hostAPI:     hostAPI,
 	}, nil
+}
+
+func (s *Server) GetWorkingDirs() []string {
+	return s.workingDirs
 }
 
 func containsInvalidCharactersWindows(path string) bool {
@@ -94,9 +96,6 @@ func (s *Server) validatePathWindows(path string) error {
 	}
 
 	valid := false
-	if strings.HasPrefix(strings.ToLower(path), strings.ToLower(s.kubeletPath)) {
-		valid = true
-	}
 	for _, workingDir := range s.workingDirs {
 		if strings.HasPrefix(strings.ToLower(path), strings.ToLower(workingDir)) {
 			valid = true
@@ -104,7 +103,7 @@ func (s *Server) validatePathWindows(path string) error {
 	}
 
 	if !valid {
-		return fmt.Errorf("path: %s is not within context path: %s or %v", path, s.kubeletPath, s.workingDirs)
+		return fmt.Errorf("path: %s is not within the working directories: %v", path, s.workingDirs)
 	}
 
 	return nil

--- a/pkg/server/filesystem/server_test.go
+++ b/pkg/server/filesystem/server_test.go
@@ -117,7 +117,7 @@ func TestMkdirWindows(t *testing.T) {
 			expectError: true,
 		},
 	}
-	srv, err := NewServer(`C:\var\lib\kubelet`, []string{}, &fakeFileSystemAPI{})
+	srv, err := NewServer([]string{`C:\var\lib\kubelet`}, &fakeFileSystemAPI{})
 	if err != nil {
 		t.Fatalf("FileSystem Server could not be initialized for testing: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestRmdirWindows(t *testing.T) {
 			expectError: true,
 		},
 	}
-	srv, err := NewServer(`C:\var\lib\kubelet`, []string{}, &fakeFileSystemAPI{})
+	srv, err := NewServer([]string{`C:\var\lib\kubelet`}, &fakeFileSystemAPI{})
 	if err != nil {
 		t.Fatalf("FileSystem Server could not be initialized for testing: %v", err)
 	}

--- a/pkg/server/smb/server_test.go
+++ b/pkg/server/smb/server_test.go
@@ -83,7 +83,7 @@ func TestNewSmbGlobalMapping(t *testing.T) {
 			expectError: false,
 		},
 	}
-	fsSrv, err := fsserver.NewServer(`C:\var\lib\kubelet`, []string{}, &fakeFileSystemAPI{})
+	fsSrv, err := fsserver.NewServer([]string{`C:\var\lib\kubelet`}, &fakeFileSystemAPI{})
 	if err != nil {
 		t.Fatalf("FileSystem Server could not be initialized for testing: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup

**What this PR does / why we need it**:
Followup of https://github.com/kubernetes-csi/csi-proxy/pull/184#discussion_r783245616

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/cc @ddebroy @jingxu97 