### PR TITLE
Autostart CSI proxy on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ On successful execution of `make build`, the output binary `csi-proxy.exe` will 
 csi-proxy.exe can be installed and run as binary or run as a Windows service on each Windows node. See the following as an example to run CSI Proxy as a web service.
 ```
     $flags = "-windows-service -log_file=C:\etc\kubernetes\logs\csi-proxy.log -logtostderr=false"
-    sc.exe create csiproxy binPath= "C:\etc\kubernetes\node\bin\csi-proxy.exe $flags"
+    sc.exe create csiproxy start= "auto" binPath= "C:\etc\kubernetes\node\bin\csi-proxy.exe $flags"
     sc.exe failure csiproxy reset= 0 actions= restart/10000
     sc.exe start csiproxy
 ```

--- a/scripts/sync-csi-proxy.ps1
+++ b/scripts/sync-csi-proxy.ps1
@@ -13,7 +13,7 @@ Copy-Item -Path "C:\Users\$env:UserName\csi-proxy.exe" -Destination "C:\etc\kube
 
 # restart the csiproxy service
 $flags = "-v=5 -windows-service -log_file=C:\etc\kubernetes\logs\csi-proxy.log -logtostderr=false"
-sc.exe create csiproxy binPath= "C:\etc\kubernetes\node\bin\csi-proxy.exe $flags"
+sc.exe create csiproxy start= "auto" binPath= "C:\etc\kubernetes\node\bin\csi-proxy.exe $flags"
 sc.exe failure csiproxy reset= 0 actions= restart/10000
 sc.exe start csiproxy
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR will fix the issue of CSI proxy not starting automatically when the Windows node is restarted.

Before this PR, the Startup type of CSI proxy was set to manual by default. 
```
PS C:\Users\Administrator> Get-Service csiproxy | select -property Status,Name,DisplayName,StartType

 Status Name     DisplayName StartType
 ------ ----     ----------- ---------
Running csiproxy csiproxy       Manual
```

If the windows node is rebooted, the CSI proxy was not started.
```
PS C:\Users\Administrator> get-service csiproxy

Status   Name               DisplayName
------   ----               -----------
Stopped  csiproxy           csiproxy
```

After this PR, CSI proxy startup type is set to automatic on boot.
```
PS C:\Users\Administrator> Get-Service csiproxy | select -property Status,Name,DisplayName,StartType

 Status Name     DisplayName StartType
 ------ ----     ----------- ---------
Running csiproxy csiproxy    Automatic
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Autostart CSI proxy on boot
```
