### PR TITLE
Reduce CSI proxy CPU usage

### DIFF
--- a/pkg/os/filesystem/api.go
+++ b/pkg/os/filesystem/api.go
@@ -3,9 +3,10 @@ package filesystem
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
 )
 
 // Implements the Filesystem OS API calls. All code here should be very simple
@@ -49,9 +50,9 @@ func (filesystemAPI) PathExists(path string) (bool, error) {
 }
 
 func pathValid(path string) (bool, error) {
-	cmd := exec.Command("powershell", "/c", `Test-Path $Env:remotepath`)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("remotepath=%s", path))
-	output, err := cmd.CombinedOutput()
+	cmd := `Test-Path $Env:remotepath`
+	cmdEnv := fmt.Sprintf("remotepath=%s", path)
+	output, err := utils.RunPowershellCmdWithEnv(cmd, cmdEnv)
 	if err != nil {
 		return false, fmt.Errorf("returned output: %s, error: %v", string(output), err)
 	}

--- a/pkg/os/filesystem/api.go
+++ b/pkg/os/filesystem/api.go
@@ -52,7 +52,7 @@ func (filesystemAPI) PathExists(path string) (bool, error) {
 func pathValid(path string) (bool, error) {
 	cmd := `Test-Path $Env:remotepath`
 	cmdEnv := fmt.Sprintf("remotepath=%s", path)
-	output, err := utils.RunPowershellCmdWithEnv(cmd, cmdEnv)
+	output, err := utils.RunPowershellCmd(cmd, cmdEnv)
 	if err != nil {
 		return false, fmt.Errorf("returned output: %s, error: %v", string(output), err)
 	}

--- a/pkg/os/iscsi/api.go
+++ b/pkg/os/iscsi/api.go
@@ -22,8 +22,8 @@ func (APIImplementor) AddTargetPortal(portal *TargetPortal) error {
 	cmdLine := fmt.Sprintf(
 		`New-IscsiTargetPortal -TargetPortalAddress ${Env:iscsi_tp_address} ` +
 			`-TargetPortalPortNumber ${Env:iscsi_tp_port}`)
-	out, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
-		fmt.Sprintf("iscsi_tp_port=%d", portal.Port)})
+	out, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
+		fmt.Sprintf("iscsi_tp_port=%d", portal.Port))
 	if err != nil {
 		return fmt.Errorf("error adding target portal. cmd %s, output: %s, err: %v", cmdLine, string(out), err)
 	}
@@ -38,8 +38,8 @@ func (APIImplementor) DiscoverTargetPortal(portal *TargetPortal) ([]string, erro
 		`ConvertTo-Json -InputObject @(Get-IscsiTargetPortal -TargetPortalAddress ` +
 			`${Env:iscsi_tp_address} -TargetPortalPortNumber ${Env:iscsi_tp_port} | ` +
 			`Get-IscsiTarget | Select-Object -ExpandProperty NodeAddress)`)
-	out, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
-		fmt.Sprintf("iscsi_tp_port=%d", portal.Port)})
+	out, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
+		fmt.Sprintf("iscsi_tp_port=%d", portal.Port))
 	if err != nil {
 		return nil, fmt.Errorf("error discovering target portal. cmd: %s, output: %s, err: %w", cmdLine, string(out), err)
 	}
@@ -78,8 +78,8 @@ func (APIImplementor) RemoveTargetPortal(portal *TargetPortal) error {
 			`-TargetPortalPortNumber ${Env:iscsi_tp_port} | Remove-IscsiTargetPortal ` +
 			`-Confirm:$false`)
 
-	out, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
-		fmt.Sprintf("iscsi_tp_port=%d", portal.Port)})
+	out, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
+		fmt.Sprintf("iscsi_tp_port=%d", portal.Port))
 	if err != nil {
 		return fmt.Errorf("error removing target portal. cmd %s, output: %s, err: %w", cmdLine, string(out), err)
 	}
@@ -98,19 +98,19 @@ func (APIImplementor) ConnectTarget(portal *TargetPortal, iqn string,
 			` -AuthenticationType ${Env:iscsi_auth_type}`)
 
 	if chapUser != "" {
-		cmdLine += fmt.Sprintf(` -ChapUsername ${Env:iscsi_chap_user}`)
+		cmdLine += ` -ChapUsername ${Env:iscsi_chap_user}`
 	}
 
 	if chapSecret != "" {
-		cmdLine += fmt.Sprintf(` -ChapSecret ${Env:iscsi_chap_secret}`)
+		cmdLine += ` -ChapSecret ${Env:iscsi_chap_secret}`
 	}
 
-	out, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
+	out, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
 		fmt.Sprintf("iscsi_tp_port=%d", portal.Port),
 		fmt.Sprintf("iscsi_target_iqn=%s", iqn),
 		fmt.Sprintf("iscsi_auth_type=%s", authType),
 		fmt.Sprintf("iscsi_chap_user=%s", chapUser),
-		fmt.Sprintf("iscsi_chap_secret=%s", chapSecret)})
+		fmt.Sprintf("iscsi_chap_secret=%s", chapSecret))
 	if err != nil {
 		return fmt.Errorf("error connecting to target portal. cmd %s, output: %s, err: %w", cmdLine, string(out), err)
 	}
@@ -126,9 +126,9 @@ func (APIImplementor) DisconnectTarget(portal *TargetPortal, iqn string) error {
 			` | Get-IscsiTarget | Where-Object { $_.NodeAddress -eq ${Env:iscsi_target_iqn} }) ` +
 			`-Confirm:$false`)
 
-	out, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
+	out, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
 		fmt.Sprintf("iscsi_tp_port=%d", portal.Port),
-		fmt.Sprintf("iscsi_target_iqn=%s", iqn)})
+		fmt.Sprintf("iscsi_target_iqn=%s", iqn))
 	if err != nil {
 		return fmt.Errorf("error disconnecting from target portal. cmd %s, output: %s, err: %w", cmdLine, string(out), err)
 	}
@@ -147,9 +147,9 @@ func (APIImplementor) GetTargetDisks(portal *TargetPortal, iqn string) ([]string
 			`$ids = $c | Get-Disk | Select -ExpandProperty Number | Out-String -Stream; ` +
 			`ConvertTo-Json -InputObject @($ids)`)
 
-	out, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
+	out, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("iscsi_tp_address=%s", portal.Address),
 		fmt.Sprintf("iscsi_tp_port=%d", portal.Port),
-		fmt.Sprintf("iscsi_target_iqn=%s", iqn)})
+		fmt.Sprintf("iscsi_target_iqn=%s", iqn))
 	if err != nil {
 		return nil, fmt.Errorf("error getting target disks. cmd %s, output: %s, err: %w", cmdLine, string(out), err)
 	}
@@ -164,9 +164,8 @@ func (APIImplementor) GetTargetDisks(portal *TargetPortal, iqn string) ([]string
 }
 
 func (APIImplementor) SetMutualChapSecret(mutualChapSecret string) error {
-	cmdLine := fmt.Sprintf(
-		`Set-IscsiChapSecret -ChapSecret ${Env:iscsi_mutual_chap_secret}`)
-	out, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("iscsi_mutual_chap_secret=%s", mutualChapSecret)})
+	cmdLine := `Set-IscsiChapSecret -ChapSecret ${Env:iscsi_mutual_chap_secret}`
+	out, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("iscsi_mutual_chap_secret=%s", mutualChapSecret))
 	if err != nil {
 		return fmt.Errorf("error setting mutual chap secret. cmd %s,"+
 			" output: %s, err: %v", cmdLine, string(out), err)

--- a/pkg/os/smb/api.go
+++ b/pkg/os/smb/api.go
@@ -25,7 +25,7 @@ func New() SmbAPI {
 func (SmbAPI) IsSmbMapped(remotePath string) (bool, error) {
 	cmdLine := `$(Get-SmbGlobalMapping -RemotePath $Env:smbremotepath -ErrorAction Stop).Status `
 	cmdEnv := fmt.Sprintf("smbremotepath=%s", remotePath)
-	out, err := utils.RunPowershellCmdWithEnv(cmdLine, cmdEnv)
+	out, err := utils.RunPowershellCmd(cmdLine, cmdEnv)
 	if err != nil {
 		return false, fmt.Errorf("error checking smb mapping. cmd %s, output: %s, err: %v", remotePath, string(out), err)
 	}
@@ -52,7 +52,7 @@ func (SmbAPI) NewSmbLink(remotePath, localPath string) error {
 	}
 
 	cmdLine := `New-Item -ItemType SymbolicLink $Env:smblocalPath -Target $Env:smbremotepath`
-	output, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("smbremotepath=%s", remotePath), fmt.Sprintf("smblocalpath=%s", localPath)})
+	output, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("smbremotepath=%s", remotePath), fmt.Sprintf("smblocalpath=%s", localPath))
 	if err != nil {
 		return fmt.Errorf("error linking %s to %s. output: %s, err: %v", remotePath, localPath, string(output), err)
 	}
@@ -67,9 +67,9 @@ func (SmbAPI) NewSmbGlobalMapping(remotePath, username, password string) error {
 		`;$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $Env:smbuser, $PWord` +
 		`;New-SmbGlobalMapping -RemotePath $Env:smbremotepath -Credential $Credential -RequirePrivacy $true`)
 
-	if output, err := utils.RunPowershellCmdWithEnvs(cmdLine, []string{fmt.Sprintf("smbuser=%s", username),
+	if output, err := utils.RunPowershellCmd(cmdLine, fmt.Sprintf("smbuser=%s", username),
 		fmt.Sprintf("smbpassword=%s", password),
-		fmt.Sprintf("smbremotepath=%s", remotePath)}); err != nil {
+		fmt.Sprintf("smbremotepath=%s", remotePath)); err != nil {
 		return fmt.Errorf("NewSmbGlobalMapping failed. output: %q, err: %v", string(output), err)
 	}
 	return nil
@@ -77,7 +77,7 @@ func (SmbAPI) NewSmbGlobalMapping(remotePath, username, password string) error {
 
 func (SmbAPI) RemoveSmbGlobalMapping(remotePath string) error {
 	cmd := `Remove-SmbGlobalMapping -RemotePath $Env:smbremotepath -Force`
-	if output, err := utils.RunPowershellCmdWithEnvs(cmd, []string{fmt.Sprintf("smbremotepath=%s", remotePath)}); err != nil {
+	if output, err := utils.RunPowershellCmd(cmd, fmt.Sprintf("smbremotepath=%s", remotePath)); err != nil {
 		return fmt.Errorf("UnmountSmbShare failed. output: %q, err: %v", string(output), err)
 	}
 	return nil

--- a/pkg/os/system/api.go
+++ b/pkg/os/system/api.go
@@ -3,9 +3,10 @@ package system
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
 )
 
 // Implements the System OS API calls. All code here should be very simple
@@ -54,12 +55,10 @@ func (APIImplementor) GetBIOSSerialNumber() (string, error) {
 func (APIImplementor) GetService(name string) (*ServiceInfo, error) {
 	script := `Get-Service -Name $env:ServiceName | Select-Object DisplayName, Status, StartType | ` +
 		`ConvertTo-JSON`
-	cmd := exec.Command("powershell", "/c", script)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("ServiceName=%s", name))
-
-	out, err := cmd.CombinedOutput()
+	cmdEnv := fmt.Sprintf("ServiceName=%s", name)
+	out, err := utils.RunPowershellCmdWithEnv(script, cmdEnv)
 	if err != nil {
-		return nil, fmt.Errorf("error querying service name=%s. cmd: %s, output: %s, error: %v", name, cmd, string(out), err)
+		return nil, fmt.Errorf("error querying service name=%s. cmd: %s, output: %s, error: %v", name, script, string(out), err)
 	}
 
 	var serviceInfo ServiceInfo
@@ -73,12 +72,10 @@ func (APIImplementor) GetService(name string) (*ServiceInfo, error) {
 
 func (APIImplementor) StartService(name string) error {
 	script := `Start-Service -Name $env:ServiceName`
-	cmd := exec.Command("powershell", "/c", script)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("ServiceName=%s", name))
-
-	out, err := cmd.CombinedOutput()
+	cmdEnv := fmt.Sprintf("ServiceName=%s", name)
+	out, err := utils.RunPowershellCmdWithEnv(script, cmdEnv)
 	if err != nil {
-		return fmt.Errorf("error starting service name=%s. cmd: %s, output: %s, error: %v", name, cmd, string(out), err)
+		return fmt.Errorf("error starting service name=%s. cmd: %s, output: %s, error: %v", name, script, string(out), err)
 	}
 
 	return nil
@@ -86,14 +83,9 @@ func (APIImplementor) StartService(name string) error {
 
 func (APIImplementor) StopService(name string, force bool) error {
 	script := `Stop-Service -Name $env:ServiceName -Force:$([System.Convert]::ToBoolean($env:Force))`
-	cmd := exec.Command("powershell", "/c", script)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("ServiceName=%s", name),
-		fmt.Sprintf("Force=%t", force))
-
-	out, err := cmd.CombinedOutput()
+	out, err := utils.RunPowershellCmdWithEnvs(script, []string{fmt.Sprintf("ServiceName=%s", name), fmt.Sprintf("Force=%t", force)})
 	if err != nil {
-		return fmt.Errorf("error stopping service name=%s. cmd: %s, output: %s, error: %v", name, cmd, string(out), err)
+		return fmt.Errorf("error stopping service name=%s. cmd: %s, output: %s, error: %v", name, script, string(out), err)
 	}
 
 	return nil

--- a/pkg/os/system/api.go
+++ b/pkg/os/system/api.go
@@ -56,7 +56,7 @@ func (APIImplementor) GetService(name string) (*ServiceInfo, error) {
 	script := `Get-Service -Name $env:ServiceName | Select-Object DisplayName, Status, StartType | ` +
 		`ConvertTo-JSON`
 	cmdEnv := fmt.Sprintf("ServiceName=%s", name)
-	out, err := utils.RunPowershellCmdWithEnv(script, cmdEnv)
+	out, err := utils.RunPowershellCmd(script, cmdEnv)
 	if err != nil {
 		return nil, fmt.Errorf("error querying service name=%s. cmd: %s, output: %s, error: %v", name, script, string(out), err)
 	}
@@ -73,7 +73,7 @@ func (APIImplementor) GetService(name string) (*ServiceInfo, error) {
 func (APIImplementor) StartService(name string) error {
 	script := `Start-Service -Name $env:ServiceName`
 	cmdEnv := fmt.Sprintf("ServiceName=%s", name)
-	out, err := utils.RunPowershellCmdWithEnv(script, cmdEnv)
+	out, err := utils.RunPowershellCmd(script, cmdEnv)
 	if err != nil {
 		return fmt.Errorf("error starting service name=%s. cmd: %s, output: %s, error: %v", name, script, string(out), err)
 	}
@@ -83,7 +83,7 @@ func (APIImplementor) StartService(name string) error {
 
 func (APIImplementor) StopService(name string, force bool) error {
 	script := `Stop-Service -Name $env:ServiceName -Force:$([System.Convert]::ToBoolean($env:Force))`
-	out, err := utils.RunPowershellCmdWithEnvs(script, []string{fmt.Sprintf("ServiceName=%s", name), fmt.Sprintf("Force=%t", force)})
+	out, err := utils.RunPowershellCmd(script, fmt.Sprintf("ServiceName=%s", name), fmt.Sprintf("Force=%t", force))
 	if err != nil {
 		return fmt.Errorf("error stopping service name=%s. cmd: %s, output: %s, error: %v", name, script, string(out), err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,19 +9,9 @@ import (
 
 const MaxPathLengthWindows = 260
 
-func RunPowershellCmd(command string) ([]byte, error) {
-	return RunPowershellCmdWithEnvs(command, nil)
-}
-
-func RunPowershellCmdWithEnv(command string, env string) ([]byte, error) {
-	return RunPowershellCmdWithEnvs(command, []string{env})
-}
-
-func RunPowershellCmdWithEnvs(command string, envs []string) ([]byte, error) {
+func RunPowershellCmd(command string, envs ...string) ([]byte, error) {
 	cmd := exec.Command("powershell", "-Mta", "-NoProfile", "-Command", command)
-	if envs != nil {
-		cmd.Env = append(os.Environ(), envs...)
-	}
+	cmd.Env = append(os.Environ(), envs...)
 	klog.V(8).Infof("Executing command: %q", cmd.String())
 	out, err := cmd.CombinedOutput()
 	return out, err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,3 +1,28 @@
 package utils
 
+import (
+	"os"
+	"os/exec"
+
+	"k8s.io/klog/v2"
+)
+
 const MaxPathLengthWindows = 260
+
+func RunPowershellCmd(command string) ([]byte, error) {
+	return RunPowershellCmdWithEnvs(command, nil)
+}
+
+func RunPowershellCmdWithEnv(command string, env string) ([]byte, error) {
+	return RunPowershellCmdWithEnvs(command, []string{env})
+}
+
+func RunPowershellCmdWithEnvs(command string, envs []string) ([]byte, error) {
+	cmd := exec.Command("powershell", "-Mta", "-NoProfile", "-Command", command)
+	if envs != nil {
+		cmd.Env = append(os.Environ(), envs...)
+	}
+	klog.V(8).Infof("Executing command: %q", cmd.String())
+	out, err := cmd.CombinedOutput()
+	return out, err
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This change will reduce CPU usage of csi proxy.
Util method to run PowerShell scripts is created. Powershell is invoked with a set of parameters to load and reduce CPU usage.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially Fixes https://github.com/kubernetes-csi/csi-proxy/issues/193

**Special notes for your reviewer**:
CPU usage in the node before this change
```
PS C:\Users\Administrator> Get-Process | Sort-Object CPU -Descending | Where-Object { $_.CPU -gt 100 }

Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
-------  ------    -----      -----     ------     --  -- -----------
    950      98   317244     236636  16,662.83   3256   0 MsMpEng
    623      32    65900      97100  10,761.61   6372   0 kubelet
    616      27     8960      16880   5,448.06   5748   0 vmcompute
   9767      32    63784      78268   4,509.66   3364   0 dockerd
  17637       0      192        136   2,590.88      4   0 System
   1880      20    14792      28340   1,657.06   5676   0 WmiPrvSE
    250      16     9748      18932   1,175.44   8676   0 svchost
    245      16    24576      20384   1,045.70   3236   0 csi-proxy
    558      57    17976      26932     845.13   6044   0 svchost
    652      17     7512      13988     804.33    576   0 svchost
    376      13    11788      16104     465.58   1316   0 svchost
    470      17    17520      26712     416.34   3076   0 svchost
    206      11     2344       8532     353.38   2608   0 svchost
   1025      25     9456      18988     315.16    904   0 lsass
    331      16    43404      40788     200.98   3552   0 svchost
    589      12     6164      10864     170.83    896   0 services
    163      15    34348      43324     128.17  10060  24 csi
    407      24    12380      24336     110.31   3100   0 vmtoolsd
    600      21     2428       5444     100.59    652   0 csrss
```

CPU usage in one of the nodes with this change
```
PS C:\Users\Administrator> Get-Process | Sort-Object CPU -Descending | Where-Object { $_.CPU -gt 100 }  

Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
-------  ------    -----      -----     ------     --  -- -----------
    501      29    62628      94044   5,303.22   4192   0 kubelet
    569      25     8200      14656   2,648.83   5984   0 vmcompute
   6131      28    59208      75296   1,715.52   3712   0 dockerd
  17306       0      196        132     958.36      4   0 System
    482      20    15480      28612     803.17   4880   0 WmiPrvSE
    278      17     8752      19524     441.97  10932   0 svchost
    536      54    12764      23084     382.58   5564   0 svchost
    632      17     6876      13400     378.16   1016   0 svchost
    235      17    22692      19708     360.34   3420   0 csi-proxy
    465      17    17256      26844     204.75   3216   0 svchost
   1025      25     8476      17684     200.31    748   0 lsass
    359      13    11168      14988     198.03   1256   0 svchost
    264      26     5724      15220     178.78   3212   0 svchost
    209      11     2300       8652     124.41   2364   0 svchost
```

Note: 
- Above info was collected on the same hardware
- Windows Defender was disabled to reduce overall system CPU usage

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Reduced CPU usage by CSI proxy in windows nodes
```
