### PR TITLE
Synchronize client files to the root vendor folder

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Windows Unit Tests
         run: |
+          make all
           go test -v -race ./pkg/...
 
   bump_version_test:

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/api/system/v1alpha1/api.pb.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/api/system/v1alpha1/api.pb.go
@@ -248,7 +248,7 @@ var xxx_messageInfo_StartServiceResponse proto.InternalMessageInfo
 type StopServiceRequest struct {
 	// Service name (as listed in System\CCS\Services keys)
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Forces stopping of services that has dependant services
+	// Forces stopping of services that has dependent services
 	Force                bool     `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/api/system/v1alpha1/api.proto
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/api/system/v1alpha1/api.proto
@@ -45,7 +45,7 @@ message StopServiceRequest {
   // Service name (as listed in System\CCS\Services keys)
   string name = 1;
 
-  // Forces stopping of services that has dependant services
+  // Forces stopping of services that has dependent services
   bool force = 2;
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
Files in client/api were updated by https://github.com/kubernetes-csi/csi-proxy/pull/198 which are supposed to be immutable, these client files weren't synchronized to the root vendor folder so the build failed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @ddebroy 
