### PR TITLE
Try to fix issue with 'Multiple connections to a server'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin/
 settings.json
 integrationtests/integrationtests.test.exe
+.vs/

--- a/pkg/server/smb/server.go
+++ b/pkg/server/smb/server.go
@@ -65,7 +65,7 @@ func (s *Server) NewSmbGlobalMapping(context context.Context, request *internal.
 
 	mappingPath, err := getRootMappingPath(remotePath)
 	if err != nil {
-		return response, err;
+		return response, err
 	}
 
 	isMapped, err := s.hostAPI.IsSmbMapped(mappingPath)
@@ -133,7 +133,7 @@ func (s *Server) RemoveSmbGlobalMapping(context context.Context, request *intern
 
 	mappingPath, err := getRootMappingPath(remotePath)
 	if err != nil {
-		return response, err;
+		return response, err
 	}
 
 	err = s.hostAPI.RemoveSmbGlobalMapping(mappingPath)

--- a/pkg/server/smb/server.go
+++ b/pkg/server/smb/server.go
@@ -25,6 +25,20 @@ func normalizeWindowsPath(path string) string {
 	return normalizedPath
 }
 
+func normalizeMappingPath(path string) string {
+	items := strings.Split(path, "\\")
+	parts := []string{}
+	for _, s := range items {
+		if len(s) > 0 {
+			parts = append(parts, s)
+			if len(parts) == 2 {
+				break
+			}
+		}
+	}
+	return strings.ToLower("\\\\" + parts[0] + "\\" + parts[1])
+}
+
 func NewServer(hostAPI smb.API, fsServer *fsserver.Server) (*Server, error) {
 	return &Server{
 		hostAPI:  hostAPI,
@@ -43,31 +57,37 @@ func (s *Server) NewSmbGlobalMapping(context context.Context, request *internal.
 		return response, fmt.Errorf("remote path is empty")
 	}
 
-	isMapped, err := s.hostAPI.IsSmbMapped(remotePath)
+	mappingPath := normalizeMappingPath(remotePath)
+
+	isMapped, err := s.hostAPI.IsSmbMapped(mappingPath)
 	if err != nil {
 		isMapped = false
 	}
 
 	if isMapped {
-		valid, err := s.fsServer.PathValid(context, remotePath)
+		klog.V(4).Infof("Remote %s already mapped. Validating...", mappingPath)
+
+		valid, err := s.fsServer.PathValid(context, mappingPath)
 		if err != nil {
-			klog.Warningf("PathValid(%s) failed with %v, ignore error", remotePath, err)
+			klog.Warningf("PathValid(%s) failed with %v, ignore error", mappingPath, err)
 		}
 
 		if !valid {
-			klog.V(4).Infof("RemotePath %s is not valid, removing now", remotePath)
-			err := s.hostAPI.RemoveSmbGlobalMapping(remotePath)
+			klog.V(4).Infof("RemotePath %s is not valid, removing now", mappingPath)
+			err := s.hostAPI.RemoveSmbGlobalMapping(mappingPath)
 			if err != nil {
-				klog.Errorf("RemoveSmbGlobalMapping(%s) failed with %v", remotePath, err)
+				klog.Errorf("RemoveSmbGlobalMapping(%s) failed with %v", mappingPath, err)
 				return response, err
 			}
 			isMapped = false
+		} else {
+			klog.V(4).Infof("RemotePath %s is valid", mappingPath)
 		}
 	}
 
 	if !isMapped {
-		klog.V(4).Infof("Remote %s not mapped. Mapping now!", remotePath)
-		err := s.hostAPI.NewSmbGlobalMapping(remotePath, request.Username, request.Password)
+		klog.V(4).Infof("Remote %s not mapped. Mapping now!", mappingPath)
+		err := s.hostAPI.NewSmbGlobalMapping(mappingPath, request.Username, request.Password)
 		if err != nil {
 			klog.Errorf("failed NewSmbGlobalMapping %v", err)
 			return response, err
@@ -75,6 +95,7 @@ func (s *Server) NewSmbGlobalMapping(context context.Context, request *internal.
 	}
 
 	if len(localPath) != 0 {
+		klog.V(4).Infof("ValidatePluginPath: '%s'", localPath)
 		err = s.fsServer.ValidatePluginPath(localPath)
 		if err != nil {
 			klog.Errorf("failed validate plugin path %v", err)
@@ -101,11 +122,13 @@ func (s *Server) RemoveSmbGlobalMapping(context context.Context, request *intern
 		return response, fmt.Errorf("remote path is empty")
 	}
 
-	err := s.hostAPI.RemoveSmbGlobalMapping(remotePath)
+	mappingPath := normalizeMappingPath(remotePath)
+	err := s.hostAPI.RemoveSmbGlobalMapping(mappingPath)
 	if err != nil {
 		klog.Errorf("failed RemoveSmbGlobalMapping %v", err)
 		return response, err
 	}
+
 	klog.V(2).Infof("RemoveSmbGlobalMapping on remote path %q is completed", request.RemotePath)
 	return response, nil
 }

--- a/pkg/server/smb/server.go
+++ b/pkg/server/smb/server.go
@@ -38,7 +38,7 @@ func getRootMappingPath(path string) (string, error) {
 	}
 	if len(parts) != 2 {
 		klog.Errorf("remote path (%s) is invalid", path)
-		return nil, fmt.Errorf("remote path (%s) is invalid", path)
+		return "", fmt.Errorf("remote path (%s) is invalid", path)
 	}
 	// parts[0] is a smb host name
 	// parts[1] is a smb share name

--- a/pkg/server/smb/server.go
+++ b/pkg/server/smb/server.go
@@ -136,7 +136,7 @@ func (s *Server) RemoveSmbGlobalMapping(context context.Context, request *intern
 		return response, err;
 	}
 
-	err := s.hostAPI.RemoveSmbGlobalMapping(mappingPath)
+	err = s.hostAPI.RemoveSmbGlobalMapping(mappingPath)
 	if err != nil {
 		klog.Errorf("failed RemoveSmbGlobalMapping %v", err)
 		return response, err

--- a/pkg/server/smb/server.go
+++ b/pkg/server/smb/server.go
@@ -63,7 +63,8 @@ func (s *Server) NewSmbGlobalMapping(context context.Context, request *internal.
 		return response, fmt.Errorf("remote path is empty")
 	}
 
-	if mappingPath, err := getRootMappingPath(remotePath); err != nil {
+	mappingPath, err := getRootMappingPath(remotePath)
+	if err != nil {
 		return response, err;
 	}
 
@@ -130,7 +131,8 @@ func (s *Server) RemoveSmbGlobalMapping(context context.Context, request *intern
 		return response, fmt.Errorf("remote path is empty")
 	}
 
-	if mappingPath, err := getRootMappingPath(remotePath); err != nil {
+	mappingPath, err := getRootMappingPath(remotePath)
+	if err != nil {
 		return response, err;
 	}
 

--- a/pkg/server/smb/server_test.go
+++ b/pkg/server/smb/server_test.go
@@ -120,12 +120,12 @@ func TestGetRootMappingPath(t *testing.T) {
 	}{
 		{
 			remote:       "",
-			expectResult: nil,
+			expectResult: "",
 			expectError:  true,
 		},
 		{
 			remote:       "hostname",
-			expectResult: nil,
+			expectResult: "",
 			expectError:  true,
 		},
 		{

--- a/pkg/server/smb/server_test.go
+++ b/pkg/server/smb/server_test.go
@@ -155,7 +155,7 @@ func TestGetRootMappingPath(t *testing.T) {
 			}
 			if expectResult != result {
 				t.Errorf("Expected (%s) but getRootMappingPath returned (%s)", expectResult, result)
-			} 
+			}
 		}
 	}
 }

--- a/pkg/server/smb/server_test.go
+++ b/pkg/server/smb/server_test.go
@@ -79,7 +79,7 @@ func TestNewSmbGlobalMapping(t *testing.T) {
 			expectError: true,
 		},
 		{
-			remote:      "\\test\\path",
+			remote:      "\\\\hostname\\path",
 			username:    "",
 			password:    "",
 			version:     v1,
@@ -108,6 +108,54 @@ func TestNewSmbGlobalMapping(t *testing.T) {
 		}
 		if !tc.expectError && err != nil {
 			t.Errorf("Expected no errors but NewSmbGlobalMapping returned error: %v", err)
+		}
+	}
+}
+
+func TestGetRootMappingPath(t *testing.T) {
+	testCases := []struct {
+		remote       string
+		expectResult string
+		expectError  bool
+	}{
+		{
+			remote:       "",
+			expectResult: nil,
+			expectError:  true,
+		},
+		{
+			remote:       "hostname",
+			expectResult: nil,
+			expectError:  true,
+		},
+		{
+			remote:       "\\\\hostname\\path",
+			expectResult: "\\\\hostname\\path",
+			expectError:  false,
+		},
+		{
+			remote:       "\\\\hostname\\path\\",
+			expectResult: "\\\\hostname\\path",
+			expectError:  false,
+		},
+		{
+			remote:       "\\\\hostname\\path\\subpath",
+			expectResult: "\\\\hostname\\path",
+			expectError:  false,
+		},
+	}
+	for _, tc := range testCases {
+		result, err := getRootMappingPath(tc.remote)
+		if tc.expectError && err == nil {
+			t.Errorf("Expected error but getRootMappingPath returned a nil error")
+		}
+		if !tc.expectError {
+			if err != nil  {
+				t.Errorf("Expected no errors but getRootMappingPath returned error: %v", err)
+			}
+			if expectResult != result {
+				t.Errorf("Expected (%s) but getRootMappingPath returned (%s)", expectResult, result)
+			} 
 		}
 	}
 }

--- a/pkg/server/smb/server_test.go
+++ b/pkg/server/smb/server_test.go
@@ -150,7 +150,7 @@ func TestGetRootMappingPath(t *testing.T) {
 			t.Errorf("Expected error but getRootMappingPath returned a nil error")
 		}
 		if !tc.expectError {
-			if err != nil  {
+			if err != nil {
 				t.Errorf("Expected no errors but getRootMappingPath returned error: %v", err)
 			}
 			if expectResult != result {

--- a/pkg/server/smb/server_test.go
+++ b/pkg/server/smb/server_test.go
@@ -153,8 +153,8 @@ func TestGetRootMappingPath(t *testing.T) {
 			if err != nil {
 				t.Errorf("Expected no errors but getRootMappingPath returned error: %v", err)
 			}
-			if expectResult != result {
-				t.Errorf("Expected (%s) but getRootMappingPath returned (%s)", expectResult, result)
+			if tc.expectResult != result {
+				t.Errorf("Expected (%s) but getRootMappingPath returned (%s)", tc.expectResult, result)
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
This PR allow to use pv/pvc for the same path more that once.
This PR allow to use many PVC based on storage class.

**Which issue(s) this PR fixes:**
Fixes https://github.com/kubernetes-csi/csi-driver-smb/issues/385

**Special notes for reviewer:**
This PR has known issue: it still doesn't work for many PVC with the same smb-path but with different credentials.

```release-note
Fix issue with impossible using a smb share more than once.
```
