### PR TITLE
master: update release-tools

### DIFF
--- a/client/apiversion/version.go
+++ b/client/apiversion/version.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/os/filesystem/api.go
+++ b/pkg/os/filesystem/api.go
@@ -61,9 +61,12 @@ func pathValid(path string) (bool, error) {
 }
 
 // PathValid determines whether all elements of a path exist
-//   https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-path?view=powershell-7
+//
+//	https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-path?view=powershell-7
+//
 // for a remote path, determines whether connection is ok
-//   e.g. in a SMB server connection, if password is changed, connection will be lost, this func will return false
+//
+//	e.g. in a SMB server connection, if password is changed, connection will be lost, this func will return false
 func (filesystemAPI) PathValid(path string) (bool, error) {
 	return pathValid(path)
 }
@@ -111,9 +114,10 @@ func (filesystemAPI) CreateSymlink(oldname, newname string) error {
 
 // IsSymlink - returns true if tgt is a mount point.
 // A path is considered a mount point if:
-//  - directory exists and
-//  - it is a soft link and
-//  - the target path of the link exists.
+//   - directory exists and
+//   - it is a soft link and
+//   - the target path of the link exists.
+//
 // If tgt path does not exist, it returns an error
 // if tgt path exists, but the source path tgt points to does not exist, it returns false without error.
 func (filesystemAPI) IsSymlink(tgt string) (bool, error) {

--- a/release-tools/go-get-kubernetes.sh
+++ b/release-tools/go-get-kubernetes.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 # This script can be used while converting a repo from "dep" to "go mod"
 # by calling it after "go mod init" or to update the Kubernetes packages
 # in a repo that has already been converted. Only packages that are

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -93,7 +93,10 @@ configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version fo
 configvar CSI_PROW_GO_VERSION_GINKGO "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building ginkgo" # depends on CSI_PROW_GINKGO_VERSION below
 
 # ginkgo test runner version to use. If the pre-installed version is
-# different, the desired version is built from source.
+# different, the desired version is built from source. For Kubernetes,
+# the version built via "make WHAT=vendor/github.com/onsi/ginkgo/ginkgo" is
+# used, which is guaranteed to match what the Kubernetes e2e.test binary
+# needs.
 configvar CSI_PROW_GINKGO_VERSION v1.7.0 "Ginkgo"
 
 # Ginkgo runs the E2E test in parallel. The default is based on the number
@@ -118,7 +121,7 @@ configvar CSI_PROW_BUILD_JOB true "building code in repo enabled"
 # use the same settings as for "latest" Kubernetes. This works
 # as long as there are no breaking changes in Kubernetes, like
 # deprecating or changing the implementation of an alpha feature.
-configvar CSI_PROW_KUBERNETES_VERSION 1.17.0 "Kubernetes"
+configvar CSI_PROW_KUBERNETES_VERSION 1.22.0 "Kubernetes"
 
 # CSI_PROW_KUBERNETES_VERSION reduced to first two version numbers and
 # with underscore (1_13 instead of 1.13.3) and in uppercase (LATEST
@@ -196,7 +199,7 @@ kindest/node:v1.14.10@sha256:f8a66ef82822ab4f7569e91a5bccaf27bceee135c1457c512e5
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.3.0" "CSI driver version"
+configvar CSI_PROW_DRIVER_VERSION "v1.8.0" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"
@@ -234,7 +237,7 @@ configvar CSI_PROW_E2E_IMPORT_PATH "k8s.io/kubernetes" "E2E package"
 # of the cluster. The alternative would have been to (cross-)compile csi-sanity
 # and install it inside the cluster, which is not necessarily easier.
 configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
-configvar CSI_PROW_SANITY_VERSION v4.3.0 "csi-test version"
+configvar CSI_PROW_SANITY_VERSION v5.0.0 "csi-test version"
 configvar CSI_PROW_SANITY_PACKAGE_PATH github.com/kubernetes-csi/csi-test "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"
@@ -346,15 +349,18 @@ configvar CSI_PROW_E2E_ALPHA "$(get_versioned_variable CSI_PROW_E2E_ALPHA "${csi
 # kubernetes-csi components must be updated, either by disabling
 # the failing test for "latest" or by updating the test and not running
 # it anymore for older releases.
-configvar CSI_PROW_E2E_ALPHA_GATES_LATEST 'GenericEphemeralVolume=true,CSIStorageCapacity=true' "alpha feature gates for latest Kubernetes"
+configvar CSI_PROW_E2E_ALPHA_GATES_LATEST '' "alpha feature gates for latest Kubernetes"
 configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_GATES "${csi_prow_kubernetes_version_suffix}")" "alpha E2E feature gates"
+
+configvar CSI_PROW_E2E_GATES_LATEST '' "non alpha feature gates for latest Kubernetes"
+configvar CSI_PROW_E2E_GATES "$(get_versioned_variable CSI_PROW_E2E_GATES "${csi_prow_kubernetes_version_suffix}")" "non alpha E2E feature gates"
 
 # Which external-snapshotter tag to use for the snapshotter CRD and snapshot-controller deployment
 default_csi_snapshotter_version () {
 	if [ "${CSI_PROW_KUBERNETES_VERSION}" = "latest" ] || [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
 		echo "master"
 	else
-		echo "v3.0.2"
+		echo "v4.0.0"
 	fi
 }
 configvar CSI_SNAPSHOTTER_VERSION "$(default_csi_snapshotter_version)" "external-snapshotter version tag"
@@ -437,6 +443,10 @@ install_kind () {
 
 # Ensure that we have the desired version of the ginkgo test runner.
 install_ginkgo () {
+    if [ -e "${CSI_PROW_BIN}/ginkgo" ]; then
+        return
+    fi
+
     # CSI_PROW_GINKGO_VERSION contains the tag with v prefix, the command line output does not.
     if [ "v$(ginkgo version 2>/dev/null | sed -e 's/.* //')" = "${CSI_PROW_GINKGO_VERSION}" ]; then
         return
@@ -940,7 +950,9 @@ install_e2e () {
         patch_kubernetes "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" "${CSI_PROW_WORK}" &&
         go_version="${CSI_PROW_GO_VERSION_E2E:-$(go_version_for_kubernetes "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" "${CSI_PROW_E2E_VERSION}")}" &&
         run_with_go "$go_version" make WHAT=test/e2e/e2e.test "-C${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" &&
-        ln -s "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}/_output/bin/e2e.test" "${CSI_PROW_WORK}"
+        ln -s "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}/_output/bin/e2e.test" "${CSI_PROW_WORK}" &&
+        run_with_go "$go_version" make WHAT=vendor/github.com/onsi/ginkgo/ginkgo "-C${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" &&
+        ln -s "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}/_output/bin/ginkgo" "${CSI_PROW_BIN}"
     else
         run_with_go "${CSI_PROW_GO_VERSION_E2E}" go test -c -o "${CSI_PROW_WORK}/e2e.test" "${CSI_PROW_E2E_IMPORT_PATH}/test/e2e"
     fi
@@ -1254,7 +1266,8 @@ main () {
         fi
 
         if tests_need_non_alpha_cluster; then
-            start_cluster || die "starting the non-alpha cluster failed"
+            # Need to (re)create the cluster.
+            start_cluster "${CSI_PROW_E2E_GATES}" || die "starting the non-alpha cluster failed"
 
             # Install necessary snapshot CRDs and snapshot controller
             install_snapshot_crds
@@ -1304,7 +1317,11 @@ main () {
             delete_cluster_inside_prow_job non-alpha
         fi
 
-        if tests_need_alpha_cluster && [ "${CSI_PROW_E2E_ALPHA_GATES}" ]; then
+        # If the cluster for alpha tests doesn't need any feature gates, then we
+        # could reuse the same cluster as for the other tests. But that would make
+        # the flow in this script harder and wouldn't help in practice because
+        # we have separate Prow jobs for alpha and non-alpha tests.
+        if tests_need_alpha_cluster; then
             # Need to (re)create the cluster.
             start_cluster "${CSI_PROW_E2E_ALPHA_GATES}" || die "starting alpha cluster failed"
 

--- a/vendor/github.com/kubernetes-csi/csi-proxy/client/apiversion/version.go
+++ b/vendor/github.com/kubernetes-csi/csi-proxy/client/apiversion/version.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Squashed 'release-tools/' changes from e4dab7f..7fe5149

[7fe5149](https://github.com/kubernetes-csi/csi-release-tools/commit/7fe5149) Merge [pull request #200](https://github.com/kubernetes-csi/csi-release-tools/pull/200) from pohly/bump-kubernetes-version
[70915a8](https://github.com/kubernetes-csi/csi-release-tools/commit/70915a8) prow.sh: update snapshotter version
[31a3f38](https://github.com/kubernetes-csi/csi-release-tools/commit/31a3f38) Merge [pull request #199](https://github.com/kubernetes-csi/csi-release-tools/pull/199) from pohly/bump-kubernetes-version
[7577454](https://github.com/kubernetes-csi/csi-release-tools/commit/7577454) prow.sh: bump Kubernetes to v1.22.0
[d29a2e7](https://github.com/kubernetes-csi/csi-release-tools/commit/d29a2e7) Merge [pull request #198](https://github.com/kubernetes-csi/csi-release-tools/pull/198) from pohly/csi-test-5.0.0
[41cb70d](https://github.com/kubernetes-csi/csi-release-tools/commit/41cb70d) prow.sh: sanity testing with csi-test v5.0.0
[c85a63f](https://github.com/kubernetes-csi/csi-release-tools/commit/c85a63f) Merge [pull request #197](https://github.com/kubernetes-csi/csi-release-tools/pull/197) from pohly/fix-alpha-testing
[b86d8e9](https://github.com/kubernetes-csi/csi-release-tools/commit/b86d8e9) support Kubernetes 1.25 + Ginkgo v2
[ab0b0a3](https://github.com/kubernetes-csi/csi-release-tools/commit/ab0b0a3) Merge [pull request #192](https://github.com/kubernetes-csi/csi-release-tools/pull/192) from andyzhangx/patch-1
[7bbab24](https://github.com/kubernetes-csi/csi-release-tools/commit/7bbab24) Merge [pull request #196](https://github.com/kubernetes-csi/csi-release-tools/pull/196) from humblec/non-alpha
[e51ff2c](https://github.com/kubernetes-csi/csi-release-tools/commit/e51ff2c) introduce control variable for non alpha feature gate configuration
[ca19ef5](https://github.com/kubernetes-csi/csi-release-tools/commit/ca19ef5) Merge [pull request #195](https://github.com/kubernetes-csi/csi-release-tools/pull/195) from pohly/fix-alpha-testing
[3948331](https://github.com/kubernetes-csi/csi-release-tools/commit/3948331) fix testing with latest Kubernetes
[9a0260c](https://github.com/kubernetes-csi/csi-release-tools/commit/9a0260c) fix boilerplate header

git-subtree-dir: release-tools
git-subtree-split: 7fe51491d8f56d0d459bf9abb9692bc9f96d2b75

```release-note
NONE
```