### PR TITLE
test: migrate tests to HostProcess pods

### DIFF
--- a/scripts/integration-test.yaml
+++ b/scripts/integration-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: integration-test
+  labels:
+    app: integration-test
+spec:
+  nodeName: windows_node # to be replaced by sed
+  securityContext:
+    windowsOptions:
+      hostProcess: true
+      runAsUserName: "NT AUTHORITY\\SYSTEM"
+  hostNetwork: true
+  containers:
+  - name: agnhost
+    image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+    command: ['powershell', '-command', 'Start-Sleep 100000']
+    volumeMounts:
+      - mountPath: /integration-test
+        name: integration-test-volume
+  nodeSelector:
+    kubernetes.io/os: windows
+  volumes:
+    - name: integration-test-volume
+      hostPath:
+        path: /
+        type: DirectoryOrCreate


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
As we migrate to a library model, the tests need to more closely mimic the runtime environment of the code, which is in HostProcess containers. Thus, this PR updates the tests to spin up a pod running HostProcess containers to execute the tests, instead of directly running the test binary on the Windows node.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #227

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @mauriciopoppe 