### PR TITLE
Bump version to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-csi/csi-proxy
+module github.com/kubernetes-csi/csi-proxy/v2
 
 go 1.16
 

--- a/integrationtests/disk_test.go
+++ b/integrationtests/disk_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/disk"
-	diskapi "github.com/kubernetes-csi/csi-proxy/pkg/disk/hostapi"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/disk"
+	diskapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/disk/hostapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/integrationtests/filesystem_test.go
+++ b/integrationtests/filesystem_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/filesystem"
-	filesystemapi "github.com/kubernetes-csi/csi-proxy/pkg/filesystem/hostapi"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem"
+	filesystemapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem/hostapi"
 )
 
 func TestFilesystem(t *testing.T) {

--- a/integrationtests/iscsi_test.go
+++ b/integrationtests/iscsi_test.go
@@ -6,12 +6,12 @@ import (
 	"strconv"
 	"testing"
 
-	disk "github.com/kubernetes-csi/csi-proxy/pkg/disk"
-	diskapi "github.com/kubernetes-csi/csi-proxy/pkg/disk/hostapi"
-	iscsi "github.com/kubernetes-csi/csi-proxy/pkg/iscsi"
-	iscsiapi "github.com/kubernetes-csi/csi-proxy/pkg/iscsi/hostapi"
-	system "github.com/kubernetes-csi/csi-proxy/pkg/system"
-	systemapi "github.com/kubernetes-csi/csi-proxy/pkg/system/hostapi"
+	disk "github.com/kubernetes-csi/csi-proxy/v2/pkg/disk"
+	diskapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/disk/hostapi"
+	iscsi "github.com/kubernetes-csi/csi-proxy/v2/pkg/iscsi"
+	iscsiapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/iscsi/hostapi"
+	system "github.com/kubernetes-csi/csi-proxy/v2/pkg/system"
+	systemapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/system/hostapi"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/integrationtests/smb_test.go
+++ b/integrationtests/smb_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	fs "github.com/kubernetes-csi/csi-proxy/pkg/filesystem"
-	fsapi "github.com/kubernetes-csi/csi-proxy/pkg/filesystem/hostapi"
-	"github.com/kubernetes-csi/csi-proxy/pkg/smb"
-	smbapi "github.com/kubernetes-csi/csi-proxy/pkg/smb/hostapi"
+	fs "github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem"
+	fsapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem/hostapi"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/smb"
+	smbapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/smb/hostapi"
 )
 
 func TestSMB(t *testing.T) {

--- a/integrationtests/system_test.go
+++ b/integrationtests/system_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	system "github.com/kubernetes-csi/csi-proxy/pkg/system"
-	systemapi "github.com/kubernetes-csi/csi-proxy/pkg/system/hostapi"
+	system "github.com/kubernetes-csi/csi-proxy/v2/pkg/system"
+	systemapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/system/hostapi"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/integrationtests/utils.go
+++ b/integrationtests/utils.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/volume"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/volume"
 )
 
 // getKubeletPathForTest returns the path to the current working directory

--- a/integrationtests/volume_test.go
+++ b/integrationtests/volume_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	disk "github.com/kubernetes-csi/csi-proxy/pkg/disk"
-	diskapi "github.com/kubernetes-csi/csi-proxy/pkg/disk/hostapi"
-	volume "github.com/kubernetes-csi/csi-proxy/pkg/volume"
-	volumeapi "github.com/kubernetes-csi/csi-proxy/pkg/volume/hostapi"
+	disk "github.com/kubernetes-csi/csi-proxy/v2/pkg/disk"
+	diskapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/disk/hostapi"
+	volume "github.com/kubernetes-csi/csi-proxy/v2/pkg/volume"
+	volumeapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/volume/hostapi"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -3,7 +3,7 @@ package disk
 import (
 	"context"
 
-	diskapi "github.com/kubernetes-csi/csi-proxy/pkg/disk/hostapi"
+	diskapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/disk/hostapi"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/disk/hostapi/hostapi.go
+++ b/pkg/disk/hostapi/hostapi.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/utils"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -3,7 +3,7 @@ package filesystem
 import (
 	"context"
 
-	filesystemapi "github.com/kubernetes-csi/csi-proxy/pkg/filesystem/hostapi"
+	filesystemapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem/hostapi"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/filesystem/filesystem_test.go
+++ b/pkg/filesystem/filesystem_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	fsapi "github.com/kubernetes-csi/csi-proxy/pkg/filesystem/hostapi"
+	fsapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem/hostapi"
 )
 
 type fakeFileSystemAPI struct{}

--- a/pkg/filesystem/hostapi/hostapi.go
+++ b/pkg/filesystem/hostapi/hostapi.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/utils"
 )
 
 // Implements the Filesystem OS API calls. All code here should be very simple

--- a/pkg/filesystem/utils.go
+++ b/pkg/filesystem/utils.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/utils"
 )
 
 var invalidPathCharsRegexWindows = regexp.MustCompile(`["/\:\?\*|]`)

--- a/pkg/iscsi/hostapi/hostapi.go
+++ b/pkg/iscsi/hostapi/hostapi.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/utils"
 )
 
 // Implements the iSCSI OS API calls. All code here should be very simple

--- a/pkg/iscsi/iscsi.go
+++ b/pkg/iscsi/iscsi.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	iscsiapi "github.com/kubernetes-csi/csi-proxy/pkg/iscsi/hostapi"
+	iscsiapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/iscsi/hostapi"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/smb/hostapi/hostapi.go
+++ b/pkg/smb/hostapi/hostapi.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/utils"
 )
 
 type HostAPI interface {

--- a/pkg/smb/smb.go
+++ b/pkg/smb/smb.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	fs "github.com/kubernetes-csi/csi-proxy/pkg/filesystem"
-	smbapi "github.com/kubernetes-csi/csi-proxy/pkg/smb/hostapi"
+	fs "github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem"
+	smbapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/smb/hostapi"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/smb/smb_test.go
+++ b/pkg/smb/smb_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	fs "github.com/kubernetes-csi/csi-proxy/pkg/filesystem"
-	fsapi "github.com/kubernetes-csi/csi-proxy/pkg/filesystem/hostapi"
-	smbapi "github.com/kubernetes-csi/csi-proxy/pkg/smb/hostapi"
+	fs "github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem"
+	fsapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/filesystem/hostapi"
+	smbapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/smb/hostapi"
 )
 
 type fakeSMBAPI struct{}

--- a/pkg/system/hostapi/hostapi.go
+++ b/pkg/system/hostapi/hostapi.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/utils"
 )
 
 // Implements the System OS API calls. All code here should be very simple

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -3,7 +3,7 @@ package system
 import (
 	"context"
 
-	systemapi "github.com/kubernetes-csi/csi-proxy/pkg/system/hostapi"
+	systemapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/system/hostapi"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/volume/hostapi/hostapi.go
+++ b/pkg/volume/hostapi/hostapi.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
+	"github.com/kubernetes-csi/csi-proxy/v2/pkg/utils"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	volumeapi "github.com/kubernetes-csi/csi-proxy/pkg/volume/hostapi"
+	volumeapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/volume/hostapi"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	volumeapi "github.com/kubernetes-csi/csi-proxy/pkg/volume/hostapi"
+	volumeapi "github.com/kubernetes-csi/csi-proxy/v2/pkg/volume/hostapi"
 )
 
 type fakeVolumeAPI struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
action required: releases CSI Proxy v2

As Windows HostProcess pods reach beta in Kubernetes 1.23, we no longer need the clients/server model of CSI Proxy to run privileged storage operations. Driver deployments can run as HostProcess containers to directly issue the privileged commands. As such, CSI Proxy is becoming a format/mount utility library similar to [kubernetes/mount-utils](https://github.com/kubernetes/mount-utils) that CSI Drivers can include to get convenience methods to execute privileged storage operations.

We have also taken advantage of the major version change to reorganize the package structure and improve some API names. Details on this version bump and a migration guide will be available in the KEP and corresponding blog post upon official release. In the mean time, we will provide usage instructions for CSI Proxy v2 in [/docs/USAGE.md](https://github.com/kubernetes-csi/csi-proxy/blob/library-development/docs/USAGE.md) on this branch for driver developers to experiment with the migration.

Below is a list of breaking changes:

1. The host binary is no longer generated. CSI Proxy becomes a regular Go library.
2. Individual API group versioning is removed. CSI Proxy maintains a single notion of version via Go module version.
3. The import path needs to include `/v2` after the repository path due to the version bump (e.g., `github.com/kubernetes-csi-proxy/v2/pkg/...`).
4. Each API group is now available under `/pkg/<API group>` as an interface defining the API and a struct implementing the interface. A `New` method is exposed under that path to initialize an instance of the struct, and it always takes in a corresponding `HostAPI` interface (previously called `API`), which is responsible for communicating with the OS, available under `/pkg/<API group>/hostapi`. The `/pkg/<API group>/hostapi` package follows a similar pattern, exposing an interface, an implementing struct, and a `New` method to initialize an instance of the struct. Previously, not every API group followed this pattern.
5. Every API group method `DoFoo` now takes in a request struct `&DoFooRequest{...}` and returns a response struct `&DoFooResponse{...}`. Previously, not every API group followed this pattern.
6. Compatibility methods to accommodate legacy API group versions are removed. Only the latest version of each API group is supported. This will continue to be the pattern in future releases of v2.
7. Go variable/struct names containing acronyms are fully capitalized, following Go style guides. Across the board, `Id`'s are renamed to `ID`s; `Smb` is renamed to `SMB`; `Iqn` is renamed to `IQN`; and `iscsi` is renamed to `iSCSI`.
8. Drivers importing CSI Proxy v2 must be deployed as HostProcess containers. See the above usage guide for migration details and caveats.
```

/cc @mauriciopoppe 