### PR TITLE
[WIP] Ensure that readonly is disabled when disks are brought online

### DIFF
--- a/pkg/os/disk/api.go
+++ b/pkg/os/disk/api.go
@@ -343,7 +343,7 @@ func (imp DiskAPI) GetDiskStats(diskNumber uint32) (int64, error) {
 }
 
 func (imp DiskAPI) SetDiskState(diskNumber uint32, isOnline bool) error {
-	cmd := fmt.Sprintf("(Get-Disk -Number %d) | Set-Disk -IsOffline $%t", diskNumber, !isOnline)
+	cmd := fmt.Sprintf("Set-Disk -Number %d -IsOffline $%t; Set-Disk -Number %d -IsReadOnly $false", diskNumber, !isOnline, diskNumber)
 	out, err := utils.RunPowershellCmd(cmd)
 	if err != nil {
 		return fmt.Errorf("error setting disk attach state. cmd: %s, output: %s, error: %v", cmd, string(out), err)

--- a/pkg/server/disk/server.go
+++ b/pkg/server/disk/server.go
@@ -198,7 +198,7 @@ func (s *Server) SetAttachState(context context.Context, request *internal.SetAt
 }
 
 func (s *Server) SetDiskState(context context.Context, request *internal.SetDiskStateRequest, version apiversion.Version) (*internal.SetDiskStateResponse, error) {
-	klog.V(2).Infof("Request: SetDiskState with diskNumber=%d and isOnline=%v", request.DiskNumber, request.IsOnline)
+	klog.V(2).Infof("Request: SetDiskState with diskNumber=%d and isOnline=%v and isReadOnly=false", request.DiskNumber, request.IsOnline)
 	err := s.hostAPI.SetDiskState(request.DiskNumber, request.IsOnline)
 	if err != nil {
 		klog.Errorf("SetDiskState failed: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR addresses the problem described below by ensuring the `readonly` attribute is cleared on Windows disks when they are attached. Bringing a disk online does not automatically ensure that it is writable, and Windows seems temperamental about whether or not it will mark a disk as `readonly`. It is best to explicitly ensure that this property is as we expect.

### Problem Summary
When moving a workload that consumes a vSphere volume and hence the volume itself to a new node, the disk is sometimes set to “read only” by Windows unless an operator manually clears the “readonly” attribute of the disk. Once an operator clears the “readonly” attribute of a disk on a node, the disk seems to remain writable on that node even if it is detached and later reattached.

### Reproducing The Problem
1. First, I created a Kubernetes v1.26.2 cluster running vSphere CSI driver version v3.0.0 with three Windows nodes. It is important that the set of Windows nodes is brand new and has never had any stateful workload attached to it. I have experienced inconsistent results when trying to perform the following steps on setups that have already attached/detached volumes in the past. Sometimes the problem does not occur.
   ```
   jrife@jrife:~/code/cluster-management$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get nodes -o wide
   NAME                      STATUS   ROLES    AGE     VERSION            INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION      CONTAINER-RUNTIME
   74566474f-j2h4c           Ready    <none>   23m     v1.26.2   21.1.3.246    21.1.3.246    Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13
   74566474f-rszzc           Ready    <none>   23m     v1.26.2   21.1.1.96     21.1.1.96     Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13
   74566474f-sp7r7           Ready    <none>   23m     v1.26.2   21.1.3.41     21.1.3.41     Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13
   ```
2. Next, I created a `StatefulSet` with one replica that would run on my Windows node pool.
   ```
   apiVersion: apps/v1
   kind: StatefulSet
   metadata:
     name: example-win-out-of-tree
   spec:
     selector:
       matchLabels:
         app: example-win-out-of-tree
     serviceName: "nginx"
     replicas: 1
     template:
       metadata:
         labels:
           app: example-win-out-of-tree
       spec:
         nodeSelector:
           kubernetes.io/os: windows
         containers:
           - name: test-container
             image: mcr.microsoft.com/windows/servercore:ltsc2019
             command:
               - "powershell.exe"
               - "-Command"
               - "while (1) { Add-Content -Encoding Ascii C:\\test\\data.txt $(Get-Date -Format u); sleep 1 }"
             volumeMounts:
             - name: test-volume
               mountPath: "/test/"
               readOnly: false
     volumeClaimTemplates:
     - metadata:
         name: test-volume
       spec:
         accessModes:
         - ReadWriteOnce
         storageClassName: standard-rwo
         resources:
           requests:
             storage: 5Gi
   ```

   ```
   jrife@jrife:~/code/cluster-management$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pods  -o wide
   NAME                         READY   STATUS        RESTARTS   AGE    IP             NODE              NOMINATED NODE   READINESS GATES
   example-win-out-of-tree-0    1/1     Running       0          96s    192.168.1.13   74566474f-sp7r7   <none>           <none>
   jrife@jrife:~/code/cluster-management$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pvc
   NAME                                     STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
   test-volume-example-win-out-of-tree-0    Bound         pvc-a8c7d9d0-0b89-45bd-a3c7-7f67a91a9d2a   5Gi        RWO            standard-rwo        103s
   ```
3. I SSHed into the node hosting the pod, `74566474f-sp7r7`, and ran `diskpart` to inspect the `readonly` attribute of the disk.
   ```
      PS C:\Users\administrator> diskpart
   
   Microsoft DiskPart version 10.0.17763.1911
   
   Copyright (C) Microsoft Corporation.
   On computer: 74566474F-72ML7
   
   DISKPART> list disk 
   
     Disk ###  Status         Size     Free     Dyn  Gpt 
     --------  -------------  -------  -------  ---  --- 
     Disk 0    Online          100 GB      0 B        *  
     Disk 1    Online           20 GB      0 B        *  
     Disk 2    Online           20 GB      0 B        *  
     Disk 3    Online           20 GB      0 B        *  
     Disk 4    Online           20 GB      0 B        *  
     Disk 5    Online           20 GB      0 B        *  
     Disk 6    Online           20 GB      0 B        *  
     Disk 7    Online           20 GB      0 B        *  
     Disk 8    Online           20 GB      0 B        *  
     Disk 9    Online           20 GB      0 B        *  
     Disk 10   Online         5120 MB      0 B        *  
     Disk 11   Online           20 GB      0 B        *  
     Disk 12   Online           20 GB      0 B        *  
   
   DISKPART> select disk 10 
   
   Disk 10 is now the selected disk. 
   
   DISKPART> attributes disk 
   Current Read-only State : No 
   Read-only  : No
   Boot Disk  : No
   Pagefile Disk  : No
   Hibernation File Disk  : No  
   Crashdump Disk  : No
   Clustered Disk  : No
   
   DISKPART>
   ```
4. I ran `kubectl cordon` on the pod’s current node then deleted the pod to force it and its volume to move to a new node, `74566474f-j2h4c`.
   ```
   jrife@jrife:~/code/cluster-management$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl cordon 74566474f-sp7r7
   node/74566474f-sp7r7 cordoned
   jrife@jrife:~/code/cluster-management$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl delete pods example-win-out-of-tree-0
   pod "example-win-out-of-tree-0" deleted
   jrife@jrife:~/code/cluster-management$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pods  -o wide
   NAME                        READY   STATUS              RESTARTS   AGE   IP       NODE              NOMINATED NODE   READINESS GATES
   example-win-out-of-tree-0   0/1     ContainerCreating   0          5s    <none>   74566474f-j2h4c   <none>           <none>
   jrife@jrife:~/code/cluster-management$ 
   ```
5. I SSHed into the node hosting the pod and ran `diskpart` to inspect the `readonly` attribute of the disk.
   ```
   PS C:\Users\administrator> diskpart
   
   Microsoft DiskPart version 10.0.17763.1911 
   
   Copyright (C) Microsoft Corporation.       
   On computer: 74566474F-J2H4C
   
   DISKPART> list disk 
   
     Disk ###  Status         Size     Free     Dyn  Gpt 
     --------  -------------  -------  -------  ---  --- 
     Disk 0    Online          100 GB      0 B        *  
     Disk 1    Online           20 GB      0 B        *  
     Disk 2    Online           20 GB      0 B        *  
     Disk 3    Online           20 GB      0 B        *  
     Disk 4    Online           20 GB      0 B        *  
     Disk 5    Online           20 GB      0 B        *  
     Disk 6    Online           20 GB      0 B        *  
     Disk 7    Online           20 GB      0 B        *  
     Disk 8    Online           20 GB      0 B        *  
     Disk 9    Online           20 GB      0 B        *  
     Disk 10   Online         5120 MB      0 B        * 
     Disk 11   Online           20 GB      0 B        * 
     Disk 12   Online           20 GB      0 B        * 
   
   DISKPART> select disk 10 
   
   Disk 10 is now the selected disk. 
   
   DISKPART> attributes disk 
   Current Read-only State : Yes 
   Read-only  : Yes
   Boot Disk  : No
   Pagefile Disk  : No
   Hibernation File Disk  : No   
   Crashdump Disk  : No
   Clustered Disk  : No
   
   DISKPART>
   ```
6. To illustrate the effect of the `readonly` attribute being set on a disk at the system level, I exec into the container and run `Set-Content` to attempt writing to the mounted volume.
   ```
   jrife@jrife:~/code/cluster-management$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl exec -it example-win-out-of-tree-0 -- powershell.exe
   Windows PowerShell
   Copyright (C) Microsoft Corporation. All rights reserved. 
   
   PS C:\> Set-Content C:\test\data.txt hello 
   Set-Content : The media is write protected. 
   At line:1 char:1
   + Set-Content C:\test\data.txt hello
   + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       + CategoryInfo          : NotSpecified: (:) [Set-Content], IOException
       + FullyQualifiedErrorId : System.IO.IOException,Microsoft.PowerShell.Commands.SetContentCommand 
    
   PS C:\> exit
   ```
7. I ran `attributes disk clear readonly` on the disk in question, moved the workload to another node, then back to this node. The disk remained writable this time.

**Which issue(s) this PR fixes**:
* [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/issues/108019) 

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
NONE

**Related Issues**:
* [kubernetes/csi-proxy: windows disk signature collision issue #287](https://github.com/kubernetes-csi/csi-proxy/issues/287)
  * Although this issue bears some similarities to what is observed here, the root cause here is stated to be a disk signature collision resulting in one disk being offline and read-only. In our case, there is only one workload and one disk that exists.
* [kubernetes/kubernetes: Disk becomes ReadOnly on Windows Node #108019](https://github.com/kubernetes/kubernetes/issues/108019)
  * This issue actually describes a similar scenario where disks are seemingly set as read-only at random by Windows that requires manual intervention by diskpart to resolve. The issue was reported to be resolved with [this patch](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1562/files) to the vSphere CSI driver that adds code to bring a disk online during resizes via csi-proxy. They also ensure the disk is online during [disk mount](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/760d1984d6b3bb8207fa7a39b3c9dced286f2507/pkg/csi/service/mounter/mounter_windows.go#L263). However, bringing a disk online does not ensure that its readonly attribute is cleared. Our tests indicate that although disks are reliably brought online during the volume mount, some volumes remain in a readonly state.
* [VMWare: Unable to initialize a second virtual disk on VMs running Windows 2008 or newer.](https://kb.vmware.com/s/article/2000767)
  * This issue sounds similar to what we observed and hints at how the Windows SAN policy may be impacting this, although some loose testing with SAN policy suggests that results are still inconsistent. Setting the SAN policy to OnlineAll does not necessarily ensure that volumes’ readonly attribute is cleared.
