### PR TITLE
Squashed 'release-tools/' changes from 78c0fb7..4133d1d

### DIFF
--- a/integrationtests/csi_api_gen_test.go
+++ b/integrationtests/csi_api_gen_test.go
@@ -16,7 +16,7 @@ import (
 // On top of this, the regular build checks that all checked-in generated files
 // are up-to-date (i.e. consistent with the current generator).
 
-// TestNewAPIGroup tests that bootstraping a new group works as intended.
+// TestNewAPIGroup tests that bootstrapping a new group works as intended.
 func TestNewAPIGroup(t *testing.T) {
 	// TODO(mauriciopoppe): this test about the generator isn't working at all
 	// the generator looks like it's working but the steps to make the diffs between the actual and desired

--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -22,17 +22,19 @@ aliases:
   - ggriffiths
   - gnufied
   - humblec
+  - mauriciopoppe
   - j-griffith
-  - Jiawei0227
   - jingxu97
   - jsafrane
   - pohly
   - RaunakShah
+  - sunnylovestiramisu
   - xing-yang
 
 # This documents who previously contributed to Kubernetes-CSI
 # as approver.
 emeritus_approvers:
+- Jiawei0227
 - lpabon
 - sbezverk
 - vladimirvivien

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -92,6 +92,8 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Check that all [canary CI
   jobs](https://k8s-testgrid.appspot.com/sig-storage-csi-ci) are passing,
   and that test coverage is adequate for the changes that are going into the release.
+1. Check that the post-\<sidecar\>-push-images builds are succeeding.
+   [Example](https://k8s-testgrid.appspot.com/sig-storage-image-build#post-external-snapshotter-push-images)
 1. Make sure that no new PRs have merged in the meantime, and no PRs are in
    flight and soon to be merged.
 1. Create a new release following a previous release as a template. Be sure to select the correct
@@ -102,7 +104,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
 1. Promote images from k8s-staging-sig-storage to k8s.gcr.io/sig-storage. From
    the [k8s image
-   repo](https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage),
+   repo](https://github.com/kubernetes/k8s.io/tree/HEAD/registry.k8s.io/images/k8s-staging-sig-storage),
    run `./generate.sh > images.yaml`, and send a PR with the updated images.
    Once merged, the image promoter will copy the images from staging to prod.
 1. Update [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs) sidecar

--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -148,7 +148,7 @@ DOCKER_BUILDX_CREATE_ARGS ?=
 $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 	set -ex; \
 	export DOCKER_CLI_EXPERIMENTAL=enabled; \
-	docker buildx create $(DOCKER_BUILDX_CREATE_ARGS) --use --name multiarchimage-buildertest; \
+	docker buildx create $(DOCKER_BUILDX_CREATE_ARGS) --use --name multiarchimage-buildertest --driver-opt image=moby/buildkit:v0.10.6; \
 	trap "docker buildx rm multiarchimage-buildertest" EXIT; \
 	dockerfile_linux=$$(if [ -e ./$(CMDS_DIR)/$*/Dockerfile ]; then echo ./$(CMDS_DIR)/$*/Dockerfile; else echo Dockerfile; fi); \
 	dockerfile_windows=$$(if [ -e ./$(CMDS_DIR)/$*/Dockerfile.Windows ]; then echo ./$(CMDS_DIR)/$*/Dockerfile.Windows; else echo Dockerfile.Windows; fi); \

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20230424-910a2a439d'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}

--- a/release-tools/filter-junit.go
+++ b/release-tools/filter-junit.go
@@ -24,7 +24,6 @@ package main
 import (
 	"encoding/xml"
 	"flag"
-	"io/ioutil"
 	"os"
 	"regexp"
 )
@@ -56,6 +55,7 @@ type TestCase struct {
 	Name      string     `xml:"name,attr"`
 	Time      string     `xml:"time,attr"`
 	SystemOut string     `xml:"system-out,omitempty"`
+	SystemErr string     `xml:"system-err,omitempty"`
 	Failure   string     `xml:"failure,omitempty"`
 	Skipped   SkipReason `xml:"skipped,omitempty"`
 }
@@ -95,7 +95,7 @@ func main() {
 			}
 		} else {
 			var err error
-			data, err = ioutil.ReadFile(input)
+			data, err = os.ReadFile(input)
 			if err != nil {
 				panic(err)
 			}
@@ -109,7 +109,7 @@ func main() {
 			if err := xml.Unmarshal(data, &junitv2); err != nil {
 				panic(err)
 			}
-			junit = junitv2.TestSuite
+			junit.TestCases = append(junit.TestCases, junitv2.TestSuite.TestCases...)
 		}
 	}
 
@@ -142,7 +142,7 @@ func main() {
 			panic(err)
 		}
 	} else {
-		if err := ioutil.WriteFile(*output, data, 0644); err != nil {
+		if err := os.WriteFile(*output, data, 0644); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
4133d1d Merge pull request #226 from msau42/cloudbuild
8d519d2 Pin buildkit to v0.10.6 to workaround v0.11 bug with docker manifest
6e04a03 Merge pull request #224 from msau42/cloudbuild
26fdfff Update cloudbuild image
6613c39 Merge pull request #223 from sunnylovestiramisu/update
0e7ae99 Update k8s image repo url
77e47cc Merge pull request #222 from xinydev/fix-dep-version
155854b Fix dep version mismatch
8f83905 Merge pull request #221 from sunnylovestiramisu/go-update
1d3f94d Update go version to 1.20 to match k/k v1.27
e322ce5 Merge pull request #220 from andyzhangx/fix-golint-error
b74a512 test: fix golint error
aa61bfd Merge pull request #218 from xing-yang/update_csi_driver
7563d19 Update CSI_PROW_DRIVER_VERSION to v1.11.0
a2171be Merge pull request #216 from msau42/process
cb98782 Merge pull request #217 from msau42/owners
a11216e add new reviewers and remove inactive reviewers
dd98675 Add step for checking builds
b66c082 Merge pull request #214 from pohly/junit-fixes
b9b6763 filter-junit.go: fix loss of testcases when parsing Ginkgo v2 JUnit
d427783 filter-junit.go: preserve system error log
38e1146 prow.sh: publish individual JUnit files as separate artifacts

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
