### PR TITLE
Cherry-pick Ensuring all paths in powershell are passes and env vars on library-development

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,8 +17,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Windows Integration Tests
         run: |
+          # required for running Volume and Disk tests
+          Install-WindowsFeature -name Hyper-V-PowerShell
+
           $env:CSI_PROXY_GH_ACTIONS="TRUE"
-          go test -v -race ./integrationtests/...
+          go test --timeout 20m -v -race ./integrationtests/...
   unit_tests:
     strategy:
       matrix:

--- a/integrationtests/disk_test.go
+++ b/integrationtests/disk_test.go
@@ -78,7 +78,6 @@ func TestDisk(t *testing.T) {
 	})
 
 	t.Run("Get/SetDiskState", func(t *testing.T) {
-		skipTestOnCondition(t, isRunningOnGhActions())
 
 		client, err := disk.New(diskapi.New())
 		require.Nil(t, err)
@@ -143,7 +142,6 @@ func TestDisk(t *testing.T) {
 	})
 
 	t.Run("PartitionDisk", func(t *testing.T) {
-		skipTestOnCondition(t, isRunningOnGhActions())
 
 		var err error
 		client, err := disk.New(diskapi.New())

--- a/integrationtests/volume_test.go
+++ b/integrationtests/volume_test.go
@@ -21,9 +21,6 @@ func TestVolume(t *testing.T) {
 		negativeVolumeTests(t)
 	})
 
-	// TODO: These tests will fail on Github Actions because Hyper-V is disabled
-	// see https://github.com/actions/virtual-environments/pull/2525
-
 	// these tests should be considered frozen from the API point of view
 	volumeClient, err := volume.New(volumeapi.New())
 	require.Nil(t, err)
@@ -32,12 +29,10 @@ func TestVolume(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("MountVolume", func(t *testing.T) {
-		skipTestOnCondition(t, isRunningOnGhActions())
 		mountVolumeTests(diskClient, volumeClient, t)
 	})
 
 	t.Run("GetClosestVolumeFromTargetPath", func(t *testing.T) {
-		skipTestOnCondition(t, isRunningOnGhActions())
 		getClosestVolumeFromTargetPathTests(diskClient, volumeClient, t)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Ensuring all paths in powershell are passes and env vars to avoid command injection attacks

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Ensuring all paths in powershell are passes as env vars
```
