### PR TITLE
Add require-privacy option for New-SmbGlobalMapping (default: true)

### DIFF
--- a/cmd/csi-proxy/main.go
+++ b/cmd/csi-proxy/main.go
@@ -34,10 +34,11 @@ func (i *workingDirFlags) Set(value string) error {
 }
 
 var (
-	kubeletPath = flag.String("kubelet-path", `C:\var\lib\kubelet`, "Prefix path of the kubelet directory in the host file system")
-	windowsSvc  = flag.Bool("windows-service", false, "Configure as a Windows Service")
-	service     *handler
-	workingDirs workingDirFlags
+	kubeletPath    = flag.String("kubelet-path", `C:\var\lib\kubelet`, "Prefix path of the kubelet directory in the host file system")
+	windowsSvc     = flag.Bool("windows-service", false, "Configure as a Windows Service")
+	requirePrivacy = flag.Bool("require-privacy", true, "If true, New-SmbGlobalMapping will be called with -RequirePrivacy $true")
+	service        *handler
+	workingDirs    workingDirFlags
 )
 
 type handler struct {
@@ -81,7 +82,8 @@ func apiGroups() ([]srvtypes.APIGroup, error) {
 	if err != nil {
 		return []srvtypes.APIGroup{}, err
 	}
-	klog.Info("Working directories: %v", fssrv.GetWorkingDirs())
+	klog.Infof("Working directories: %v", fssrv.GetWorkingDirs())
+	klog.Infof("Require privacy: %t", *requirePrivacy)
 
 	volumesrv, err := volumesrv.NewServer(volumeapi.New())
 	if err != nil {
@@ -93,7 +95,7 @@ func apiGroups() ([]srvtypes.APIGroup, error) {
 		return []srvtypes.APIGroup{}, err
 	}
 
-	smbsrv, err := smbsrv.NewServer(smbapi.New(), fssrv)
+	smbsrv, err := smbsrv.NewServer(smbapi.New(*requirePrivacy), fssrv)
 	if err != nil {
 		return []srvtypes.APIGroup{}, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently New-SmbGlobalMapping is called always with option `-RequirePrivacy $true`. It might be a reason for the issue when SMB server doesn't support encryption. This PR allows to change this behavior by adding new flag (-require-privacy) to csi-proxy.exe. It is true by default for backward compatibility. If we want to allow call New-SmbGlobalMapping without -RequirePrivacy $true just add `-require-privacy=false` to csi-proxy arguments.

```release-note
The flag (-require-privacy) has been added. If true, New-SmbGlobalMapping will be called with -RequirePrivacy $true
```
