### PR TITLE
Update the github action workflow to run the integration tests

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.22']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -15,27 +15,43 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Build
+        shell: powershell
         run: |
           go build -v -a -o ./bin/csi-proxy.exe ./cmd/csi-proxy
           go build -v -a -o ./bin/csi-proxy-api-gen.exe ./cmd/csi-proxy-api-gen
       - name: Run Windows Integration Tests
+        shell: powershell
         run: |
-          # required for running Volume and Disk tests
+          # This scripts reimplements scripts/run-integration.sh in powershell.
+
+          # Nested virtualization is required for running Volume and Disk tests
           Install-WindowsFeature -name Hyper-V-PowerShell
-          
-          # start the CSI Proxy before running tests on windows
-          Start-Job -Name CSIProxy -ScriptBlock {
-            .\bin\csi-proxy.exe
-          };
-          Start-Sleep -Seconds 30;
-          Write-Output "getting named pipes"
+
+          # copy the binary from the user directory
+          New-Item -ItemType Directory -Path C:\etc\kubernetes\node\bin -Force
+          New-Item -ItemType Directory -Path C:\etc\kubernetes\logs -Force
+          Copy-Item -Path .\bin\csi-proxy.exe -Destination "C:\etc\kubernetes\node\bin\csi-proxy.exe"
+
+          # restart the csiproxy service
+          $flags = "-v=5 -windows-service -log_file=C:\etc\kubernetes\logs\csi-proxy.log -logtostderr=false"
+          sc.exe create csiproxy start= "auto" binPath= "C:\etc\kubernetes\node\bin\csi-proxy.exe $flags"
+          sc.exe failure csiproxy reset= 0 actions= restart/10000
+          sc.exe start csiproxy
+
+          Start-Sleep -Seconds 5;
+
+          Write-Output "Checking the status of csi-proxy"
+          sc.exe query csiproxy
           [System.IO.Directory]::GetFiles("\\.\\pipe\\")
+          Write-Output "Get CSI Proxy logs"
+          Get-Content C:\etc\kubernetes\logs\csi-proxy.log -Tail 20
+
           $env:CSI_PROXY_GH_ACTIONS="TRUE"
           go test -timeout 20m -v -race ./integrationtests/...
   unit_tests:
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.22']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -53,7 +69,7 @@ jobs:
   bump_version_test:
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.22']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
A presubmit is failing because of a change in the github actions default Windows VM https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/, I used the same code in `scripts/run-integration.sh` rewritten in powershell.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
