### PR TITLE
Add min go runtime to be 1.23 and add  godebug winsymlink=0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        go: ['1.22']
+        go: ['1.23']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -51,7 +51,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        go: ['1.22']
+        go: ['1.23']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -69,7 +69,7 @@ jobs:
   bump_version_test:
     strategy:
       matrix:
-        go: ['1.22']
+        go: ['1.23']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kubernetes-csi/csi-proxy
 
-go 1.20
+go 1.23
+
+godebug winsymlink=0
 
 require (
 	github.com/Microsoft/go-winio v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

This is in response to this thread
https://groups.google.com/g/container-storage-interface-community/c/btNUUr67OMA/m/DFk-N-dBAQAJ

---
golang 1.23 has made some significant changes to how Windows mount points are reported. We are still evaluating the impact, so until we fully understand what fixes we may need to make, CSI drivers and csi-proxy should either:

1. Hold off on upgrading to golang 1.23 until we provide further guidance. This also means refraining from updating [k8s.io/mount-utils](http://k8s.io/mount-utils) to v0.32.0
2. If upgrading to golang 1.23, add the "godebug winsymlink=0" flag to the go.mod file to disable these changes.

See https://github.com/kubernetes/kubernetes/issues/129080 for more details.

---

Through https://github.com/kubernetes-csi/csi-proxy/pull/362 we used go 1.23 to build the binary so I think we should set a min go version and `godebug winsymlink=0` in go.mod

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Set min go version to 1.23 and godebug winsymlink=0 in go.mod
```

/cc @msau42 