### PR TITLE
Revert "Add min go runtime to be 1.23 and add  godebug winsymlink=0"

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
-          skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh
+          skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh,./docs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -51,7 +51,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -69,7 +69,7 @@ jobs:
   bump_version_test:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/kubernetes-csi/csi-proxy
 
-go 1.23
+// NOTE: This project must be built with go < 1.23
+// `make build` will error if go1.23 or higher is used.
 
-godebug winsymlink=0
+go 1.22.0
+
+toolchain go1.22.3
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/scripts/run-integration.sh
+++ b/scripts/run-integration.sh
@@ -18,6 +18,10 @@ pkgdir=${GOPATH}/src/github.com/kubernetes-csi/csi-proxy
 source $pkgdir/scripts/utils.sh
 
 main() {
+  # TODO: remove go version pin as part of https://github.com/kubernetes-csi/csi-proxy/issues/361
+  wget -q https://go.dev/dl/go1.22.12.linux-amd64.tar.gz
+  rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.12.linux-amd64.tar.gz
+
   compile_csi_proxy
   compile_csi_proxy_integration_tests
   sync_csi_proxy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

This reverts commit ab5cffa8e3b3cec98139884f6fd2867f9041d434. While this added go 1.23 support with compat flags we're still learning what changes might be needed in kubelet to make the windows storage privileged ops to work with go 1.23 without compat flags.

Ref https://github.com/kubernetes-csi/csi-proxy/issues/361

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Revert using go 1.23 + compat flags to go 1.20 in go.mod
```

/cc @msau42 @sunnylovestiramisu 