### PR TITLE
Automated cherry pick of #369: Revert "Add min go runtime to be 1.23 and add  godebug

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
-          skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh
+          skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh,./docs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -51,7 +51,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -69,7 +69,7 @@ jobs:
   bump_version_test:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kubernetes-csi/csi-proxy
 
-go 1.23
-
-godebug winsymlink=0
+go 1.22.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
Cherry pick of #369 on release-1.2.

/kind feature

#369: Revert "Add min go runtime to be 1.23 and add  godebug

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Revert using go 1.23 + compat flags to go 1.20 in go.mod
```