### PR TITLE
Automated cherry pick of #369: Revert "Add min go runtime to be 1.23 and add  godebug

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
-          skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh
+          skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh,./docs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -51,7 +51,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -69,7 +69,7 @@ jobs:
   bump_version_test:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/kubernetes-csi/csi-proxy
 
-go 1.23
+// NOTE: This project must be built with go < 1.23
+// `make build` will error if go1.23 or higher is used.
 
-godebug winsymlink=0
+go 1.22.0
+
+toolchain go1.22.3
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/scripts/run-integration.sh
+++ b/scripts/run-integration.sh
@@ -18,6 +18,10 @@ pkgdir=${GOPATH}/src/github.com/kubernetes-csi/csi-proxy
 source $pkgdir/scripts/utils.sh
 
 main() {
+  # TODO: remove go version pin as part of https://github.com/kubernetes-csi/csi-proxy/issues/361
+  wget -q https://go.dev/dl/go1.22.12.linux-amd64.tar.gz
+  rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.12.linux-amd64.tar.gz
+
   compile_csi_proxy
   compile_csi_proxy_integration_tests
   sync_csi_proxy


### PR DESCRIPTION
Cherry pick of #369 on release-1.2.

#369: Revert "Add min go runtime to be 1.23 and add  godebug

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Revert "Add min go runtime to be 1.23" added in #363. The project min go runtime is 1.22.
```

/cc @sunnylovestiramisu 