### PR TITLE
feat: Use WMI to create SMB Global Mapping to reduce PowerShell overhead

### DIFF
--- a/pkg/cim/smb.go
+++ b/pkg/cim/smb.go
@@ -1,0 +1,53 @@
+//go:build windows
+// +build windows
+
+package cim
+
+import (
+	"github.com/microsoft/wmi/pkg/base/query"
+	cim "github.com/microsoft/wmi/pkg/wmiinstance"
+)
+
+// Refer to https://learn.microsoft.com/en-us/previous-versions/windows/desktop/smb/msft-smbmapping
+const (
+	SmbMappingStatusOK int32 = iota
+	SmbMappingStatusPaused
+	SmbMappingStatusDisconnected
+	SmbMappingStatusNetworkError
+	SmbMappingStatusConnecting
+	SmbMappingStatusReconnecting
+	SmbMappingStatusUnavailable
+)
+
+// QuerySmbGlobalMappingByRemotePath retrieves the SMB global mapping from its remote path.
+//
+// The equivalent WMI query is:
+//
+//	SELECT [selectors] FROM MSFT_SmbGlobalMapping
+//
+// Refer to https://pkg.go.dev/github.com/microsoft/wmi/server2019/root/microsoft/windows/smb#MSFT_SmbGlobalMapping
+// for the WMI class definition.
+func QuerySmbGlobalMappingByRemotePath(remotePath string) (*cim.WmiInstance, error) {
+	smbQuery := query.NewWmiQuery("MSFT_SmbGlobalMapping", "RemotePath", remotePath)
+	instances, err := QueryInstances(WMINamespaceSmb, smbQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	return instances[0], err
+}
+
+// RemoveSmbGlobalMappingByRemotePath removes a SMB global mapping matching to the remote path.
+//
+// Refer to https://pkg.go.dev/github.com/microsoft/wmi/server2019/root/microsoft/windows/smb#MSFT_SmbGlobalMapping
+// for the WMI class definition.
+func RemoveSmbGlobalMappingByRemotePath(remotePath string) error {
+	smbQuery := query.NewWmiQuery("MSFT_SmbGlobalMapping", "RemotePath", remotePath)
+	instances, err := QueryInstances(WMINamespaceSmb, smbQuery)
+	if err != nil {
+		return err
+	}
+
+	_, err = instances[0].InvokeMethod("Remove", true)
+	return err
+}

--- a/pkg/cim/wmi.go
+++ b/pkg/cim/wmi.go
@@ -18,6 +18,7 @@ import (
 const (
 	WMINamespaceRoot    = "Root\\CimV2"
 	WMINamespaceStorage = "Root\\Microsoft\\Windows\\Storage"
+	WMINamespaceSmb     = "Root\\Microsoft\\Windows\\Smb"
 )
 
 type InstanceHandler func(instance *cim.WmiInstance) (bool, error)

--- a/pkg/os/smb/api.go
+++ b/pkg/os/smb/api.go
@@ -6,12 +6,12 @@ import (
 	"syscall"
 
 	"github.com/kubernetes-csi/csi-proxy/pkg/cim"
+	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
 	"golang.org/x/sys/windows"
 )
 
 const (
 	credentialDelimiter = ":"
-	longPathPrefix      = `\\?\`
 )
 
 type API interface {
@@ -88,14 +88,8 @@ func (*SmbAPI) NewSmbLink(remotePath, localPath string) error {
 		// so add one if needed.
 		remotePath = remotePath + "\\"
 	}
-	longRemotePath := remotePath
-	if !strings.HasPrefix(longRemotePath, longPathPrefix) {
-		longRemotePath = longPathPrefix + longRemotePath
-	}
-	longLocalPath := localPath
-	if !strings.HasPrefix(longLocalPath, longPathPrefix) {
-		longLocalPath = longPathPrefix + longLocalPath
-	}
+	longRemotePath := utils.EnsureLongPath(remotePath)
+	longLocalPath := utils.EnsureLongPath(localPath)
 
 	err := createSymlink(longLocalPath, longRemotePath, true)
 	if err != nil {

--- a/pkg/os/smb/api.go
+++ b/pkg/os/smb/api.go
@@ -45,15 +45,21 @@ func escapeUserName(userName string) string {
 }
 
 func createSymlink(link, target string, isDir bool) error {
-	linkPtr, _ := syscall.UTF16PtrFromString(link)
-	targetPtr, _ := syscall.UTF16PtrFromString(target)
+	linkPtr, err := syscall.UTF16PtrFromString(link)
+	if err != nil {
+		return err
+	}
+	targetPtr, err := syscall.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
 
 	var flags uint32
 	if isDir {
 		flags = windows.SYMBOLIC_LINK_FLAG_DIRECTORY
 	}
 
-	err := windows.CreateSymbolicLink(
+	err = windows.CreateSymbolicLink(
 		linkPtr,
 		targetPtr,
 		flags,

--- a/pkg/os/volume/api.go
+++ b/pkg/os/volume/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-ole/go-ole"
 	"github.com/kubernetes-csi/csi-proxy/pkg/cim"
+	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
 	wmierrors "github.com/microsoft/wmi/pkg/errors"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
@@ -57,8 +58,6 @@ var (
 	// PS C:\disks> (Get-Disk -Number 1 | Get-Partition | Get-Volume).UniqueId
 	// \\?\Volume{452e318a-5cde-421e-9831-b9853c521012}\
 	VolumeRegexp = regexp.MustCompile(`Volume\{[\w-]*\}`)
-	// longPathPrefix is the prefix of Windows long path
-	longPathPrefix = "\\\\?\\"
 
 	notMountedFolder = errors.New("not a mounted folder")
 )
@@ -337,7 +336,7 @@ func getTarget(mount string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	targetPath := longPathPrefix + windows.UTF16PtrToString(&outPathBuffer[0])
+	targetPath := utils.EnsureLongPath(windows.UTF16PtrToString(&outPathBuffer[0]))
 	if !strings.HasSuffix(targetPath, "\\") {
 		targetPath += "\\"
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,11 +3,24 @@ package utils
 import (
 	"os"
 	"os/exec"
+	"strings"
 
 	"k8s.io/klog/v2"
 )
 
-const MaxPathLengthWindows = 260
+const (
+	MaxPathLengthWindows = 260
+
+	// LongPathPrefix is the prefix of Windows long path
+	LongPathPrefix = `\\?\`
+)
+
+func EnsureLongPath(path string) string {
+	if !strings.HasPrefix(path, LongPathPrefix) {
+		path = LongPathPrefix + path
+	}
+	return path
+}
 
 func RunPowershellCmd(command string, envs ...string) ([]byte, error) {
 	cmd := exec.Command("powershell", "-Mta", "-NoProfile", "-Command", command)


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR leverages of WMI interfaces to replace the PowerShell functions for SMB NewSmbGlobalMapping API,
It improves the overall performance of csi-proxy.
Partially for https://github.com/kubernetes-csi/csi-proxy/issues/193

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
