### PR TITLE
feat: Migrate PathValid API to use Win32 API to reduce PowerShell overhead

### DIFF
--- a/pkg/os/filesystem/api.go
+++ b/pkg/os/filesystem/api.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
 )
@@ -49,17 +48,6 @@ func (filesystemAPI) PathExists(path string) (bool, error) {
 	return pathExists(path)
 }
 
-func pathValid(path string) (bool, error) {
-	cmd := `Test-Path $Env:remotepath`
-	cmdEnv := fmt.Sprintf("remotepath=%s", path)
-	output, err := utils.RunPowershellCmd(cmd, cmdEnv)
-	if err != nil {
-		return false, fmt.Errorf("returned output: %s, error: %v", string(output), err)
-	}
-
-	return strings.HasPrefix(strings.ToLower(string(output)), "true"), nil
-}
-
 // PathValid determines whether all elements of a path exist
 //
 //	https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-path?view=powershell-7
@@ -68,7 +56,7 @@ func pathValid(path string) (bool, error) {
 //
 //	e.g. in a SMB server connection, if password is changed, connection will be lost, this func will return false
 func (filesystemAPI) PathValid(path string) (bool, error) {
-	return pathValid(path)
+	return utils.IsPathValid(path)
 }
 
 // Mkdir makes a dir with `os.MkdirAll`.

--- a/pkg/os/filesystem/api_test.go
+++ b/pkg/os/filesystem/api_test.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"testing"
 
+	"github.com/kubernetes-csi/csi-proxy/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +26,7 @@ func TestPathValid(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result, err := pathValid(test.remotepath)
+		result, err := utils.IsPathValid(test.remotepath)
 		assert.Equal(t, result, test.expectedResult, "Expect result not equal with pathValid(%s) return: %q, expected: %q, error: %v",
 			test.remotepath, result, test.expectedResult, err)
 		if test.expectError {


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Migrate the PathValid API to use `GetFileAttribute` to reduce PowerShell overhead.

**Which issue(s) this PR fixes**:
Fixes #193 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
