### PR TITLE
Replace wmic with PowerShell's Get-CimInstance cmdlet

### DIFF
--- a/integrationtests/system_test.go
+++ b/integrationtests/system_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -25,13 +24,13 @@ func TestGetBIOSSerialNumber(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, response)
 
-		result, err := exec.Command("wmic", "bios", "get", "serialnumber").Output()
-		require.Nil(t, err)
+		serialNumber, err := runPowershellCmd(t, fmt.Sprintf(`(Get-CimInstance -ClassName Win32_BIOS).SerialNumber`))
+		if err != nil {
+			t.Fatalf("command to get serial number failed: %v", err)
+		}
+		t.Logf("The serial number is %s", serialNumber)
 
-		t.Logf("The serial number is %s", response.SerialNumber)
-
-		resultString := string(result)
-		require.True(t, strings.Contains(resultString, response.SerialNumber))
+		require.True(t, strings.Contains(serialNumber, response.SerialNumber))
 	})
 }
 
@@ -57,7 +56,7 @@ func TestServiceCommands(t *testing.T) {
 			ServiceName))
 		require.NoError(t, err)
 
-		var serviceInfo = struct {
+		serviceInfo := struct {
 			DisplayName string `json:"DisplayName"`
 			Status      uint32 `json:"Status"`
 			StartType   uint32 `json:"StartType"`
@@ -96,7 +95,6 @@ func TestServiceCommands(t *testing.T) {
 		assert.NotNil(t, stopResp)
 		assertServiceStopped(t, ServiceName)
 	})
-
 }
 
 func assertServiceStarted(t *testing.T, serviceName string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind failing-test

**What this PR does / why we need it**:

Replace wmic with PowerShell's Get-CimInstance cmdlet. wmic is deprecated and might have stopped working in the github actions worker.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @laozc 