### PR TITLE
[library-development] chore: upgrade to go1.25

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        go: ['1.24']
+        go: ['1.25']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -30,7 +30,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        go: ['1.24']
+        go: ['1.25']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.prow.sh
+++ b/.prow.sh
@@ -6,6 +6,9 @@
 : ${CSI_PROW_TESTS:="unit"}
 : ${CSI_PROW_BUILD_PLATFORMS:="windows amd64 .exe"}
 
+# go.mod requires go >= 1.25.0; override the default Go version in release-tools.
+: ${CSI_PROW_GO_VERSION_BUILD:="1.25.0"}
+
 . release-tools/prow.sh
 
 # This creates the CSI_PROW_WORK directory that is needed by run_with_go.

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/kubernetes-csi/csi-proxy/v2
 
-go 1.24.3
+go 1.25.0
 
 godebug winsymlink=0
-
-toolchain go1.24.4
 
 require (
 	github.com/go-ole/go-ole v1.3.0


### PR DESCRIPTION
Cherry-pick of #446 to library-development branch.

**What this PR does:**

Backports the Go 1.25 upgrade to the library-development branch.

**Cherry-picked commits:**
- `f5ce138` chore: upgrade to go1.25
- `ebade92` ci: bump Go to 1.25 in windows workflow to match go.mod
- `b186e59` ci: override CSI_PROW_GO_VERSION_BUILD to 1.25.0 for prow

**Conflicts resolved:**
- `go.mod`: kept `module github.com/kubernetes-csi/csi-proxy/v2` (library-development module path), updated go version to 1.25.0
- `.github/workflows/windows.yml`: kept library-development structure (without bump_version_test job from master), bumped Go version to 1.25