### PR TITLE
[library-development] chore: upgrade to go1.25

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        go: ['1.24']
+        go: ['1.25']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -30,7 +30,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        go: ['1.24']
+        go: ['1.25']
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go }}
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run Windows Integration Tests

--- a/.prow.sh
+++ b/.prow.sh
@@ -6,6 +6,9 @@
 : ${CSI_PROW_TESTS:="unit"}
 : ${CSI_PROW_BUILD_PLATFORMS:="windows amd64 .exe"}
 
+# go.mod requires go >= 1.25.0; override the default Go version in release-tools.
+: ${CSI_PROW_GO_VERSION_BUILD:="1.25.0"}
+
 . release-tools/prow.sh
 
 # This creates the CSI_PROW_WORK directory that is needed by run_with_go.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kubernetes-csi/csi-proxy/v2
 
-go 1.24.3
-
-toolchain go1.24.4
+go 1.25.0
 
 require (
 	github.com/go-ole/go-ole v1.3.0


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Backports the Go 1.25 upgrade to the `library-development` branch.
Includes CI configuration updates for GitHub Actions (`windows.yml`) and Prow (`.prow.sh`).

Supersedes #457.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```